### PR TITLE
fix(args): raise default max completed requests to 2

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -9,7 +9,7 @@ pub struct Args {
     #[arg(long)]
     pub tokenizer: Option<String>,
 
-    #[arg(long, default_value = "1")]
+    #[arg(long, default_value = "2")]
     pub max_num_completed_requests: u32,
 
     #[arg(long, default_value = "1")]


### PR DESCRIPTION
Set the default max completed requests flag to 2 so the CLI can handle two completions out of the box.