### PR TITLE
chore(deps): update root dependencies to latest releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,7 @@ dependencies = [
  "libc",
  "log",
  "rand 0.9.2",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -732,6 +733,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -1523,6 +1525,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rand_distr = "0.5.1"
 sanitize-filename = "0.6.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-tokenizers = { version = "0.22.1", features = ["http"] }
+tokenizers = { version = "0.22.1", features = ["http", "rustls-tls"] }
 tokio = { version = "1.44.1", features = ["full"] }
 
 # The profile that 'dist' will build with


### PR DESCRIPTION
## Summary
- bump the root dependency set
- enable tokenizers rustls-tls feature to use rustls (no OpenSSL)
- refresh `Cargo.lock`