### PR TITLE
feat(cli): add --no-progress flag for non-interactive runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,42 +1,34 @@
 # Changelog
 
-## [Unreleased]
+## Unreleased
 
-### CI / Build
+### Enhancements
 
-- Bump cargo-dist to v0.30.2 in release workflow. ([#7](https://github.com/jpreagan/llmnop/pull/7))
+- `--no-progress` CLI flag to disable the progress bar for non-interactive environments.
 
 ## 0.3.0
 
-Released on 2025-10-27
+Released on 2025-10-27.
 
-### Added
+### Enhancements
 
-- `--tokenizer` CLI flag to allow a different tokenizer name than the served model name (e.g., `--model gpt-oss:20b --tokenizer openai/gpt-oss-20b`). Also writes `tokenizer` into the summary JSON and bumps the summary schema version field to `2025-10-05`. ([#1](https://github.com/jpreagan/llmnop/pull/1))
-
-### Changed
-
-- Default `--max-num-completed-requests` from 1 → 2, so two completions can be handled out of the box. ([#3](https://github.com/jpreagan/llmnop/pull/3))
-- Dependency refresh; `tokenizers` now built with `rustls-tls` (no OpenSSL dependency). ([#4](https://github.com/jpreagan/llmnop/pull/4))
-
-### CI / Build
-
-- Upgrade `cargo-dist` to v0.30; enable shell + Homebrew installers; use `$XDG_BIN_HOME` / `~/.local/bin` install paths; docs refreshed. ([#2](https://github.com/jpreagan/llmnop/pull/2))
-
-### Notes
-
-- No breaking changes expected. New CLI flag is optional.
+- Allow different tokenizer than served model via `--tokenizer`; write `tokenizer` to summary JSON and bump schema to `2025-10-05`. ([#1](https://github.com/jpreagan/llmnop/pull/1))
+- Add shell installer + Homebrew formula; default install now respects `$XDG_BIN_HOME` (or `~/.local/bin`). ([#2](https://github.com/jpreagan/llmnop/pull/2))
+- Increase default `--max-num-completed-requests` to 2. ([#3](https://github.com/jpreagan/llmnop/pull/3))
+- Build `tokenizers` with `rustls-tls` (drops OpenSSL dependency). ([#4](https://github.com/jpreagan/llmnop/pull/4))
 
 ## 0.2.0
 
-Released on 2025-07-12
+Released on 2025-07-12.
 
-- Upgraded the project to Rust 2024 edition, and MSRV is now v1.85.
-- Added a benchmark summary that prints aggregated statistics to stdout.
-- Flattened the benchmark-results JSON structure.
+### Enhancements
+
+- Upgrade to Rust 2024 edition (MSRV v1.85).
+- Add benchmark summary output.
+- Flatten benchmark-results JSON.
 
 ## 0.1.0
 
-Released on 2025-07-09
+Released on 2025-07-09.
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ llmnop [OPTIONS] --model <MODEL>
     --stddev-output-tokens <STDDEV_OUTPUT_TOKENS>              [default: 10]
     --results-dir <RESULTS_DIR>                                [default: result_outputs]
     --timeout <TIMEOUT>                                        [default: 600]
+    --no-progress                                              Disable the progress bar (useful for non-interactive environments)
 -h, --help                                                     Print help
 -V, --version                                                  Print version
 ```

--- a/src/args.rs
+++ b/src/args.rs
@@ -32,4 +32,7 @@ pub struct Args {
 
     #[arg(long, default_value = "600")]
     pub timeout: u64,
+
+    #[arg(long, help = "Disable the progress bar (useful for non-interactive environments)")]
+    pub no_progress: bool,
 }


### PR DESCRIPTION
## Summary

- add a `--no-progress` flag to turn off the progress bar in non-interactive environments
- detect stderr TTY state and hide the progress bar automatically when absent
- document the new flag