### PR TITLE
fix: clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -173,11 +173,9 @@ async fn main() -> Result<()> {
     let mut total_output_tokens = 0_u64;
     let num_errors = all_results.iter().filter(|r| r.is_err()).count();
 
-    for result in &all_results {
-        if let Ok(br) = result {
-            total_output_tokens += br.output_tokens as u64;
-            successful_results.push(br.clone());
-        }
+    for br in all_results.iter().flatten() {
+        total_output_tokens += br.output_tokens as u64;
+        successful_results.push(br.clone());
     }
 
     print_summary_to_stdout(

--- a/src/output.rs
+++ b/src/output.rs
@@ -279,7 +279,7 @@ pub fn write_results_json(
     {
         let file_name = format!(
             "{}_{}_{}_individual_responses.json",
-            sanitize_filename::sanitize(model.replace('/', "-").replace('.', "-")),
+            sanitize_filename::sanitize(model.replace(['/', '.'], "-")),
             mean_input_tokens,
             mean_output_tokens
         );
@@ -293,7 +293,7 @@ pub fn write_results_json(
     {
         let summary_filename = format!(
             "{}_{}_{}_summary.json",
-            sanitize_filename::sanitize(model.replace('/', "-").replace('.', "-")),
+            sanitize_filename::sanitize(model.replace(['/', '.'], "-")),
             mean_input_tokens,
             mean_output_tokens
         );
@@ -398,7 +398,7 @@ fn build_flattened_summary(
         version: "2025-10-05".to_string(),
         name: format!(
             "{}_{}_{}_summary",
-            sanitize_filename::sanitize(model.replace('/', "-").replace('.', "-")),
+            sanitize_filename::sanitize(model.replace(['/', '.'], "-")),
             mean_input_tokens,
             mean_output_tokens
         ),


### PR DESCRIPTION
- Use \`replace(['/', '.'], "-")\` instead of chained \`.replace()\` calls
- Use \`.flatten()\` instead of manual \`if let Ok\`