### PR TITLE
fix: use max_completion_tokens instead of deprecated max_tokens

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -42,7 +42,7 @@ pub async fn create_chat_completion_stream(
             .into()]);
 
     if let Some(tokens) = max_tokens {
-        builder.max_tokens(tokens);
+        builder.max_completion_tokens(tokens);
     }
 
     let request = builder.build().context("Failed to build request")?;


### PR DESCRIPTION
## Summary

- Replaces deprecated `max_tokens` with `max_completion_tokens` in chat completion requests

## Context

The OpenAI API deprecated `max_tokens` in favor of `max_completion_tokens`. The newer parameter is required for o-series reasoning models and is the recommended approach going forward.