### PR TITLE
feat(api): add anthropic messages api support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+
+- Add Anthropic Messages API support via `--api messages`. ([#36](https://github.com/jpreagan/llmnop/pull/36))
+
 ## [0.9.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ### Added
 
 - Add Anthropic Messages API support via `--api messages`. ([#36](https://github.com/jpreagan/llmnop/pull/36))
+- Add `--thinking-budget-tokens` for Anthropic Messages API extended thinking. ([#36](https://github.com/jpreagan/llmnop/pull/36))
 
 ## [0.9.0]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
  "futures",
  "getrandom 0.3.4",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-eventsource",
  "secrecy",
  "serde",
@@ -165,6 +165,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axoasset"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,7 +197,7 @@ dependencies = [
  "lazy_static",
  "miette",
  "mime",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -311,6 +333,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -378,10 +402,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "comfy-table"
@@ -645,6 +688,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +783,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -903,7 +958,7 @@ dependencies = [
  "libc",
  "log",
  "rand 0.9.2",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1235,6 +1290,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1424,7 @@ dependencies = [
  "indicatif 0.18.4",
  "rand 0.10.0",
  "rand_distr",
+ "reqwest 0.13.3",
  "sanitize-filename",
  "serde",
  "serde_json",
@@ -1672,6 +1787,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -1920,9 +2036,49 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -1937,7 +2093,7 @@ dependencies = [
  "mime",
  "nom",
  "pin-project-lite",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 1.0.69",
 ]
 
@@ -1962,6 +2118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,6 +2145,7 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2012,11 +2178,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2193,6 +2387,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2811,6 +3021,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,6 +3063,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.3.31"
 indicatif = "0.18.0"
 rand = "0.10.0"
 rand_distr = "0.6.0"
+reqwest = { version = "0.13.1", default-features = false, features = ["json", "stream", "rustls"] }
 sanitize-filename = "0.6.0"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/README.md
+++ b/README.md
@@ -77,30 +77,25 @@ Results print to stdout and save under the llmnop app results directory:
 
 ### Endpoint
 
-| Flag            | Description                                            |
-| --------------- | ------------------------------------------------------ |
-| `--url`         | Base URL (e.g., `http://localhost:8000/v1`)            |
-| `--api-key`     | API key for authentication                             |
-| `--model`, `-m` | Model name to benchmark                                |
-| `--api`         | API type: `chat` (default), `responses`, or `messages` |
+| Flag            | Description                                 |
+| --------------- | ------------------------------------------- |
+| `--url`         | Base URL (e.g., `http://localhost:8000/v1`) |
+| `--api-key`     | API key for authentication                  |
+| `--model`, `-m` | Model name to benchmark                     |
+| `--api`         | API type: `chat` (default) or `responses`   |
 
-`chat` targets OpenAI's [Chat Completions API](https://platform.openai.com/docs/api-reference/chat). `responses` targets the [Responses API](https://platform.openai.com/docs/api-reference/responses) format, compatible with both OpenAI and [Open Responses](https://huggingface.co/blog/open-responses) servers. `messages` targets Anthropic's Messages API.
+`chat` targets OpenAI's [Chat Completions API](https://platform.openai.com/docs/api-reference/chat). `responses` targets the [Responses API](https://platform.openai.com/docs/api-reference/responses) format, compatible with both OpenAI and [Open Responses](https://huggingface.co/blog/open-responses) servers.
 
 ### Request Shaping
 
 Control input and output token counts to simulate realistic workloads:
 
-| Flag                       | Default | Description                                               |
-| -------------------------- | ------- | --------------------------------------------------------- |
-| `--mean-input-tokens`      | 550     | Target prompt length in tokens                            |
-| `--stddev-input-tokens`    | 0       | Add variance to input length                              |
-| `--mean-output-tokens`     | none    | Mean output token cap to request                          |
-| `--stddev-output-tokens`   | 0       | Add variance to output length                             |
-| `--thinking-budget-tokens` | none    | Enable Anthropic Messages thinking with this token budget |
-
-For `--api messages`, `--mean-output-tokens` is required so llmnop can set `max_tokens` in the request.
-When `--thinking-budget-tokens` is set, it must be at least 1024 and smaller than `--mean-output-tokens`.
-If `--use-server-token-count` is set for a Messages API thinking stream and the server only reports aggregate `output_tokens`, llmnop uses local tokenization for the output/reasoning split instead of treating aggregate tokens as visible output.
+| Flag                     | Default | Description                                               |
+| ------------------------ | ------- | --------------------------------------------------------- |
+| `--mean-input-tokens`    | 550     | Target prompt length in tokens                            |
+| `--stddev-input-tokens`  | 0       | Add variance to input length                              |
+| `--mean-output-tokens`   | none    | Cap output length (recommended for consistent benchmarks) |
+| `--stddev-output-tokens` | 0       | Add variance to output length                             |
 
 ### Load Testing
 
@@ -153,14 +148,6 @@ llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
 ```bash
 llmnop --api responses --url http://localhost:8000/v1 --api-key token-abc123 \
   --model openai/gpt-oss-120b
-```
-
-**Anthropic Messages API:**
-
-```bash
-llmnop --api messages --url http://localhost:8000/v1 --api-key token-abc123 \
-  --model Qwen/Qwen3.6-27B \
-  --mean-output-tokens 4096
 ```
 
 **JSON stdout for `jq` pipelines:**

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Results print to stdout and save under the llmnop app results directory:
 | `--url`         | Base URL (e.g., `http://localhost:8000/v1`) |
 | `--api-key`     | API key for authentication                  |
 | `--model`, `-m` | Model name to benchmark                     |
-| `--api`         | API type: `chat` (default) or `responses`   |
+| `--api`         | API type: `chat` (default), `responses`, or `messages` |
 
-`chat` targets OpenAI's [Chat Completions API](https://platform.openai.com/docs/api-reference/chat). `responses` targets the [Responses API](https://platform.openai.com/docs/api-reference/responses) format, compatible with both OpenAI and [Open Responses](https://huggingface.co/blog/open-responses) servers.
+`chat` targets OpenAI's [Chat Completions API](https://platform.openai.com/docs/api-reference/chat). `responses` targets the [Responses API](https://platform.openai.com/docs/api-reference/responses) format, compatible with both OpenAI and [Open Responses](https://huggingface.co/blog/open-responses) servers. `messages` targets Anthropic's Messages API.
 
 ### Request Shaping
 
@@ -96,6 +96,8 @@ Control input and output token counts to simulate realistic workloads:
 | `--stddev-input-tokens`  | 0       | Add variance to input length                              |
 | `--mean-output-tokens`   | none    | Cap output length (recommended for consistent benchmarks) |
 | `--stddev-output-tokens` | 0       | Add variance to output length                             |
+
+For `--api messages`, `--mean-output-tokens` is required so llmnop can set `max_tokens` in the request.
 
 ### Load Testing
 
@@ -157,6 +159,14 @@ llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
   --model Qwen/Qwen3-4B-Instruct-2507 \
   --output-format json \
   --max-num-completed-requests 1 | jq '.request_latency.p99'
+```
+
+**Anthropic Messages API:**
+
+```bash
+llmnop --api messages --url https://api.anthropic.com/v1 --api-key $ANTHROPIC_API_KEY \
+  --model claude-haiku-4-5 \
+  --mean-output-tokens 150
 ```
 
 **Custom tokenizer when model name doesn't match Hugging Face:**

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ Results print to stdout and save under the llmnop app results directory:
 
 ### Endpoint
 
-| Flag            | Description                                 |
-| --------------- | ------------------------------------------- |
-| `--url`         | Base URL (e.g., `http://localhost:8000/v1`) |
-| `--api-key`     | API key for authentication                  |
-| `--model`, `-m` | Model name to benchmark                     |
+| Flag            | Description                                            |
+| --------------- | ------------------------------------------------------ |
+| `--url`         | Base URL (e.g., `http://localhost:8000/v1`)            |
+| `--api-key`     | API key for authentication                             |
+| `--model`, `-m` | Model name to benchmark                                |
 | `--api`         | API type: `chat` (default), `responses`, or `messages` |
 
 `chat` targets OpenAI's [Chat Completions API](https://platform.openai.com/docs/api-reference/chat). `responses` targets the [Responses API](https://platform.openai.com/docs/api-reference/responses) format, compatible with both OpenAI and [Open Responses](https://huggingface.co/blog/open-responses) servers. `messages` targets Anthropic's Messages API.
@@ -90,12 +90,12 @@ Results print to stdout and save under the llmnop app results directory:
 
 Control input and output token counts to simulate realistic workloads:
 
-| Flag                       | Default | Description                                              |
-| -------------------------- | ------- | -------------------------------------------------------- |
-| `--mean-input-tokens`      | 550     | Target prompt length in tokens                           |
-| `--stddev-input-tokens`    | 0       | Add variance to input length                             |
-| `--mean-output-tokens`     | none    | Mean output token cap to request                         |
-| `--stddev-output-tokens`   | 0       | Add variance to output length                            |
+| Flag                       | Default | Description                                               |
+| -------------------------- | ------- | --------------------------------------------------------- |
+| `--mean-input-tokens`      | 550     | Target prompt length in tokens                            |
+| `--stddev-input-tokens`    | 0       | Add variance to input length                              |
+| `--mean-output-tokens`     | none    | Mean output token cap to request                          |
+| `--stddev-output-tokens`   | 0       | Add variance to output length                             |
 | `--thinking-budget-tokens` | none    | Enable Anthropic Messages thinking with this token budget |
 
 For `--api messages`, `--mean-output-tokens` is required so llmnop can set `max_tokens` in the request.
@@ -155,6 +155,14 @@ llmnop --api responses --url http://localhost:8000/v1 --api-key token-abc123 \
   --model openai/gpt-oss-120b
 ```
 
+**Anthropic Messages API:**
+
+```bash
+llmnop --api messages --url http://localhost:8000/v1 --api-key token-abc123 \
+  --model Qwen/Qwen3.6-27B \
+  --mean-output-tokens 4096
+```
+
 **JSON stdout for `jq` pipelines:**
 
 ```bash
@@ -162,26 +170,6 @@ llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
   --model Qwen/Qwen3-4B-Instruct-2507 \
   --output-format json \
   --max-num-completed-requests 1 | jq '.request_latency.p99'
-```
-
-**Anthropic Messages API:**
-
-```bash
-llmnop --api messages --url https://api.anthropic.com/v1 --api-key $ANTHROPIC_API_KEY \
-  --model claude-haiku-4-5 \
-  --tokenizer Xenova/claude-tokenizer \
-  --mean-output-tokens 150
-```
-
-**Anthropic Messages API with thinking:**
-
-```bash
-llmnop --api messages --url https://api.anthropic.com/v1 --api-key $ANTHROPIC_API_KEY \
-  --model claude-haiku-4-5 \
-  --tokenizer Xenova/claude-tokenizer \
-  --mean-output-tokens 1100 \
-  --thinking-budget-tokens 1024 \
-  --use-server-token-count
 ```
 
 **Custom tokenizer when model name doesn't match Hugging Face:**

--- a/README.md
+++ b/README.md
@@ -90,14 +90,17 @@ Results print to stdout and save under the llmnop app results directory:
 
 Control input and output token counts to simulate realistic workloads:
 
-| Flag                     | Default | Description                                               |
-| ------------------------ | ------- | --------------------------------------------------------- |
-| `--mean-input-tokens`    | 550     | Target prompt length in tokens                            |
-| `--stddev-input-tokens`  | 0       | Add variance to input length                              |
-| `--mean-output-tokens`   | none    | Cap output length (recommended for consistent benchmarks) |
-| `--stddev-output-tokens` | 0       | Add variance to output length                             |
+| Flag                       | Default | Description                                              |
+| -------------------------- | ------- | -------------------------------------------------------- |
+| `--mean-input-tokens`      | 550     | Target prompt length in tokens                           |
+| `--stddev-input-tokens`    | 0       | Add variance to input length                             |
+| `--mean-output-tokens`     | none    | Mean output token cap to request                         |
+| `--stddev-output-tokens`   | 0       | Add variance to output length                            |
+| `--thinking-budget-tokens` | none    | Enable Anthropic Messages thinking with this token budget |
 
 For `--api messages`, `--mean-output-tokens` is required so llmnop can set `max_tokens` in the request.
+When `--thinking-budget-tokens` is set, it must be at least 1024 and smaller than `--mean-output-tokens`.
+If `--use-server-token-count` is set for a Messages API thinking stream and the server only reports aggregate `output_tokens`, llmnop uses local tokenization for the output/reasoning split instead of treating aggregate tokens as visible output.
 
 ### Load Testing
 
@@ -166,7 +169,19 @@ llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
 ```bash
 llmnop --api messages --url https://api.anthropic.com/v1 --api-key $ANTHROPIC_API_KEY \
   --model claude-haiku-4-5 \
+  --tokenizer Xenova/claude-tokenizer \
   --mean-output-tokens 150
+```
+
+**Anthropic Messages API with thinking:**
+
+```bash
+llmnop --api messages --url https://api.anthropic.com/v1 --api-key $ANTHROPIC_API_KEY \
+  --model claude-haiku-4-5 \
+  --tokenizer Xenova/claude-tokenizer \
+  --mean-output-tokens 1100 \
+  --thinking-budget-tokens 1024 \
+  --use-server-token-count
 ```
 
 **Custom tokenizer when model name doesn't match Hugging Face:**

--- a/src/args.rs
+++ b/src/args.rs
@@ -82,7 +82,7 @@ pub struct Args {
 
     #[arg(
         long,
-        help = "Target output length [default: none]",
+        help = "Mean output token cap to request [default: none]",
         help_heading = "Request Shaping"
     )]
     pub mean_output_tokens: Option<u32>,
@@ -94,6 +94,13 @@ pub struct Args {
         help_heading = "Request Shaping"
     )]
     pub stddev_output_tokens: u32,
+
+    #[arg(
+        long,
+        help = "Enable Anthropic Messages thinking with this token budget",
+        help_heading = "Request Shaping"
+    )]
+    pub thinking_budget_tokens: Option<u32>,
 
     // Load Testing
     #[arg(
@@ -195,6 +202,23 @@ impl Args {
         if matches!(self.api, ApiType::Messages) && self.mean_output_tokens.is_none() {
             return Err("--mean-output-tokens is required for --api messages".to_string());
         }
+        if let Some(thinking_budget) = self.thinking_budget_tokens {
+            if !matches!(self.api, ApiType::Messages) {
+                return Err("--thinking-budget-tokens requires --api messages".to_string());
+            }
+            if thinking_budget < 1024 {
+                return Err("--thinking-budget-tokens must be at least 1024".to_string());
+            }
+            let mean_output_tokens = self
+                .mean_output_tokens
+                .expect("--mean-output-tokens is required for --api messages");
+            if mean_output_tokens <= thinking_budget {
+                return Err(
+                    "--mean-output-tokens must be greater than --thinking-budget-tokens"
+                        .to_string(),
+                );
+            }
+        }
         Ok(())
     }
 }
@@ -288,6 +312,94 @@ mod tests {
             "test-key",
             "--mean-output-tokens",
             "150",
+        ])
+        .expect("parse args");
+
+        assert!(args.validate().is_ok());
+    }
+
+    #[test]
+    fn test_thinking_budget_requires_messages_api() {
+        let args = Args::try_parse_from([
+            "llmnop",
+            "--api",
+            "chat",
+            "--model",
+            "test-model",
+            "--url",
+            "http://localhost:8000/v1",
+            "--api-key",
+            "test-key",
+            "--mean-output-tokens",
+            "1500",
+            "--thinking-budget-tokens",
+            "1024",
+        ])
+        .expect("parse args");
+
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn test_thinking_budget_requires_at_least_1024_tokens() {
+        let args = Args::try_parse_from([
+            "llmnop",
+            "--api",
+            "messages",
+            "--model",
+            "test-model",
+            "--url",
+            "https://api.anthropic.com/v1",
+            "--api-key",
+            "test-key",
+            "--mean-output-tokens",
+            "1500",
+            "--thinking-budget-tokens",
+            "1023",
+        ])
+        .expect("parse args");
+
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn test_thinking_budget_requires_larger_mean_output_tokens() {
+        let args = Args::try_parse_from([
+            "llmnop",
+            "--api",
+            "messages",
+            "--model",
+            "test-model",
+            "--url",
+            "https://api.anthropic.com/v1",
+            "--api-key",
+            "test-key",
+            "--mean-output-tokens",
+            "1024",
+            "--thinking-budget-tokens",
+            "1024",
+        ])
+        .expect("parse args");
+
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn test_thinking_budget_allows_messages_api() {
+        let args = Args::try_parse_from([
+            "llmnop",
+            "--api",
+            "messages",
+            "--model",
+            "test-model",
+            "--url",
+            "https://api.anthropic.com/v1",
+            "--api-key",
+            "test-key",
+            "--mean-output-tokens",
+            "1500",
+            "--thinking-budget-tokens",
+            "1024",
         ])
         .expect("parse args");
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -9,6 +9,7 @@ use clap::{CommandFactory, Parser, ValueEnum};
 pub enum ApiType {
     Chat,
     Responses,
+    Messages,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
@@ -189,6 +190,13 @@ impl Args {
             self.output_format
         }
     }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if matches!(self.api, ApiType::Messages) && self.mean_output_tokens.is_none() {
+            return Err("--mean-output-tokens is required for --api messages".to_string());
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -228,6 +236,62 @@ mod tests {
         .expect("parse args");
 
         assert!(matches!(args.api, ApiType::Responses));
+    }
+
+    #[test]
+    fn test_parse_messages_api_type() {
+        let args = Args::try_parse_from([
+            "llmnop",
+            "--api",
+            "messages",
+            "--model",
+            "test-model",
+            "--url",
+            "https://api.anthropic.com/v1",
+            "--api-key",
+            "test-key",
+        ])
+        .expect("parse args");
+
+        assert!(matches!(args.api, ApiType::Messages));
+    }
+
+    #[test]
+    fn test_messages_api_requires_mean_output_tokens() {
+        let args = Args::try_parse_from([
+            "llmnop",
+            "--api",
+            "messages",
+            "--model",
+            "test-model",
+            "--url",
+            "https://api.anthropic.com/v1",
+            "--api-key",
+            "test-key",
+        ])
+        .expect("parse args");
+
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn test_messages_api_allows_mean_output_tokens() {
+        let args = Args::try_parse_from([
+            "llmnop",
+            "--api",
+            "messages",
+            "--model",
+            "test-model",
+            "--url",
+            "https://api.anthropic.com/v1",
+            "--api-key",
+            "test-key",
+            "--mean-output-tokens",
+            "150",
+        ])
+        .expect("parse args");
+
+        assert!(args.validate().is_ok());
     }
 
     #[test]

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -37,6 +37,7 @@ pub struct BenchmarkRequest {
     pub model: String,
     pub prompt: String,
     pub max_tokens: Option<u32>,
+    pub thinking_budget_tokens: Option<u32>,
     pub tokenizer: String,
     pub use_server_token_count: bool,
 }
@@ -232,8 +233,14 @@ async fn run_messages_benchmark(
     let mut reasoning_text = String::new();
     let mut usage: Option<MessagesUsage> = None;
 
-    let mut stream =
-        create_messages_stream(client, &request.model, &request.prompt, max_tokens).await?;
+    let mut stream = create_messages_stream(
+        client,
+        &request.model,
+        &request.prompt,
+        max_tokens,
+        request.thinking_budget_tokens,
+    )
+    .await?;
     while let Some(event_result) = stream.next().await {
         let event = event_result?;
         let now = Instant::now();
@@ -276,9 +283,27 @@ async fn run_messages_benchmark(
     let end_time = Instant::now();
     let request_end_unix_ns = unix_time_now_ns();
 
+    if generated_text.is_empty()
+        && reasoning_text.is_empty()
+        && usage
+            .as_ref()
+            .and_then(|usage| usage.output_tokens)
+            .is_some_and(|output_tokens| output_tokens > 0)
+    {
+        let output_tokens = usage.and_then(|usage| usage.output_tokens).unwrap_or(0);
+        return Err(anyhow!(
+            "Messages API reported {output_tokens} output tokens but streamed no text or thinking deltas"
+        ));
+    }
+
+    let use_server_token_count = should_use_messages_server_token_count(
+        request.use_server_token_count,
+        usage.as_ref(),
+        &reasoning_text,
+    );
     let usage_counts = usage.as_ref().and_then(token_counts_from_messages_usage);
     let token_counts = resolve_token_counts(
-        request.use_server_token_count,
+        use_server_token_count,
         usage_counts,
         &request.prompt,
         &generated_text,
@@ -334,14 +359,38 @@ fn token_counts_from_responses_usage(usage: &ResponsesUsage) -> Option<TokenCoun
 
 fn token_counts_from_messages_usage(usage: &MessagesUsage) -> Option<TokenCounts> {
     let input = usage.input_tokens?;
-    let output = usage.output_tokens?;
+    let output_total = usage.output_tokens?;
+    let reasoning = messages_usage_reasoning_tokens(usage).unwrap_or(0);
+    let output = output_total.saturating_sub(reasoning);
 
     Some(TokenCounts {
         input,
         output,
-        reasoning: 0,
-        total: input + output,
+        reasoning,
+        total: input + output_total,
     })
+}
+
+fn messages_usage_reasoning_tokens(usage: &MessagesUsage) -> Option<u32> {
+    usage
+        .output_tokens_details
+        .as_ref()
+        .and_then(|details| details.reasoning_tokens)
+        .or_else(|| {
+            usage
+                .completion_tokens_details
+                .as_ref()
+                .and_then(|details| details.reasoning_tokens)
+        })
+}
+
+fn should_use_messages_server_token_count(
+    requested: bool,
+    usage: Option<&MessagesUsage>,
+    reasoning_text: &str,
+) -> bool {
+    requested
+        && (reasoning_text.is_empty() || usage.and_then(messages_usage_reasoning_tokens).is_some())
 }
 
 fn merge_messages_usage(
@@ -358,6 +407,12 @@ fn merge_messages_usage(
             }
             if new_usage.output_tokens.is_some() {
                 existing.output_tokens = new_usage.output_tokens;
+            }
+            if new_usage.output_tokens_details.is_some() {
+                existing.output_tokens_details = new_usage.output_tokens_details;
+            }
+            if new_usage.completion_tokens_details.is_some() {
+                existing.completion_tokens_details = new_usage.completion_tokens_details;
             }
             Some(existing)
         }
@@ -521,6 +576,8 @@ fn unix_time_now_ns() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use crate::client::anthropic::messages::MessagesOutputTokensDetails;
+
     use super::*;
     use crate::client::openai::responses::ResponsesOutputTokensDetails;
     use async_openai::types::chat::CompletionTokensDetails;
@@ -954,6 +1011,8 @@ mod tests {
         let usage = MessagesUsage {
             input_tokens: Some(12),
             output_tokens: Some(8),
+            output_tokens_details: None,
+            completion_tokens_details: None,
         };
 
         let counts = token_counts_from_messages_usage(&usage).expect("counts");
@@ -964,18 +1023,82 @@ mod tests {
     }
 
     #[test]
+    fn test_token_counts_from_messages_usage_with_reasoning() {
+        let usage = MessagesUsage {
+            input_tokens: Some(12),
+            output_tokens: Some(8),
+            output_tokens_details: Some(MessagesOutputTokensDetails {
+                reasoning_tokens: Some(3),
+            }),
+            completion_tokens_details: None,
+        };
+
+        let counts = token_counts_from_messages_usage(&usage).expect("counts");
+        assert_eq!(counts.input, 12);
+        assert_eq!(counts.output, 5);
+        assert_eq!(counts.reasoning, 3);
+        assert_eq!(counts.total, 20);
+    }
+
+    #[test]
+    fn test_messages_server_counts_disabled_for_aggregate_reasoning_stream() {
+        let usage = MessagesUsage {
+            input_tokens: Some(12),
+            output_tokens: Some(8),
+            output_tokens_details: None,
+            completion_tokens_details: None,
+        };
+
+        assert!(!should_use_messages_server_token_count(
+            true,
+            Some(&usage),
+            "thinking"
+        ));
+    }
+
+    #[test]
+    fn test_messages_server_counts_allowed_for_reasoning_split() {
+        let usage = MessagesUsage {
+            input_tokens: Some(12),
+            output_tokens: Some(8),
+            output_tokens_details: Some(MessagesOutputTokensDetails {
+                reasoning_tokens: Some(3),
+            }),
+            completion_tokens_details: None,
+        };
+
+        assert!(should_use_messages_server_token_count(
+            true,
+            Some(&usage),
+            "thinking"
+        ));
+    }
+
+    #[test]
     fn test_merge_messages_usage_prefers_latest_values() {
         let current = MessagesUsage {
             input_tokens: Some(10),
             output_tokens: Some(1),
+            output_tokens_details: None,
+            completion_tokens_details: None,
         };
         let update = MessagesUsage {
             input_tokens: None,
             output_tokens: Some(12),
+            output_tokens_details: Some(MessagesOutputTokensDetails {
+                reasoning_tokens: Some(3),
+            }),
+            completion_tokens_details: None,
         };
 
         let merged = merge_messages_usage(Some(current), Some(update)).expect("merged");
         assert_eq!(merged.input_tokens, Some(10));
         assert_eq!(merged.output_tokens, Some(12));
+        assert_eq!(
+            merged
+                .output_tokens_details
+                .and_then(|details| details.reasoning_tokens),
+            Some(3)
+        );
     }
 }

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -1,6 +1,12 @@
 use crate::args::ApiType;
-use crate::client::{
-    ResponsesStreamEvent, ResponsesUsage, create_chat_completion_stream, create_responses_stream,
+use crate::client::ApiClient;
+use crate::client::anthropic::messages::{
+    MessagesClient, MessagesContentDelta, MessagesStreamEvent, MessagesUsage,
+    create_messages_stream,
+};
+use crate::client::openai::chat::create_chat_completion_stream;
+use crate::client::openai::responses::{
+    ResponsesStreamEvent, ResponsesUsage, create_responses_stream,
 };
 use crate::tokens;
 use anyhow::{Result, anyhow};
@@ -43,13 +49,29 @@ struct TokenCounts {
 }
 
 pub async fn run_benchmark(
-    client: &Client<OpenAIConfig>,
+    client: &ApiClient,
     api: ApiType,
     request: BenchmarkRequest,
 ) -> Result<BenchmarkResult> {
     match api {
-        ApiType::Chat => run_chat_benchmark(client, &request).await,
-        ApiType::Responses => run_responses_benchmark(client, &request).await,
+        ApiType::Chat => {
+            let client = client
+                .openai()
+                .ok_or_else(|| anyhow!("OpenAI client unavailable"))?;
+            run_chat_benchmark(client, &request).await
+        }
+        ApiType::Responses => {
+            let client = client
+                .openai()
+                .ok_or_else(|| anyhow!("OpenAI client unavailable"))?;
+            run_responses_benchmark(client, &request).await
+        }
+        ApiType::Messages => {
+            let client = client
+                .anthropic_messages()
+                .ok_or_else(|| anyhow!("Anthropic Messages client unavailable"))?;
+            run_messages_benchmark(client, &request).await
+        }
     }
 }
 
@@ -145,19 +167,17 @@ async fn run_responses_benchmark(
         let now = Instant::now();
 
         match event {
-            ResponsesStreamEvent::OutputTextDelta { delta: Some(text) } => {
-                if !text.is_empty() {
-                    content_arrivals.push((now, text.clone()));
-                    generated_text.push_str(&text);
-                }
+            ResponsesStreamEvent::OutputTextDelta { delta: Some(text) } if !text.is_empty() => {
+                content_arrivals.push((now, text.clone()));
+                generated_text.push_str(&text);
             }
             ResponsesStreamEvent::ReasoningTextDelta { delta: Some(text) }
             | ResponsesStreamEvent::ReasoningSummaryTextDelta { delta: Some(text) }
-            | ResponsesStreamEvent::ReasoningDelta { delta: Some(text) } => {
-                if !text.is_empty() {
-                    reasoning_arrivals.push((now, text.clone()));
-                    reasoning_text.push_str(&text);
-                }
+            | ResponsesStreamEvent::ReasoningDelta { delta: Some(text) }
+                if !text.is_empty() =>
+            {
+                reasoning_arrivals.push((now, text.clone()));
+                reasoning_text.push_str(&text);
             }
             ResponsesStreamEvent::ResponseCompleted { response } => {
                 usage = response.and_then(|response| response.usage);
@@ -177,6 +197,86 @@ async fn run_responses_benchmark(
     let request_end_unix_ns = unix_time_now_ns();
 
     let usage_counts = usage.as_ref().and_then(token_counts_from_responses_usage);
+    let token_counts = resolve_token_counts(
+        request.use_server_token_count,
+        usage_counts,
+        &request.prompt,
+        &generated_text,
+        &reasoning_text,
+        &request.tokenizer,
+    )?;
+
+    Ok(process_benchmark_data_with_timestamps(
+        start_time,
+        end_time,
+        &content_arrivals,
+        &reasoning_arrivals,
+        &token_counts,
+        request_start_unix_ns,
+        request_end_unix_ns,
+    ))
+}
+
+async fn run_messages_benchmark(
+    client: &MessagesClient,
+    request: &BenchmarkRequest,
+) -> Result<BenchmarkResult> {
+    let max_tokens = request
+        .max_tokens
+        .ok_or_else(|| anyhow!("Messages API requires --mean-output-tokens (max_tokens)"))?;
+    let request_start_unix_ns = unix_time_now_ns();
+    let start_time = Instant::now();
+    let mut content_arrivals: Vec<(Instant, String)> = Vec::new();
+    let mut reasoning_arrivals: Vec<(Instant, String)> = Vec::new();
+    let mut generated_text = String::new();
+    let mut reasoning_text = String::new();
+    let mut usage: Option<MessagesUsage> = None;
+
+    let mut stream =
+        create_messages_stream(client, &request.model, &request.prompt, max_tokens).await?;
+    while let Some(event_result) = stream.next().await {
+        let event = event_result?;
+        let now = Instant::now();
+
+        match event {
+            MessagesStreamEvent::ContentBlockDelta {
+                delta: MessagesContentDelta::TextDelta { text: Some(text) },
+            } if !text.is_empty() => {
+                content_arrivals.push((now, text.clone()));
+                generated_text.push_str(&text);
+            }
+            MessagesStreamEvent::ContentBlockDelta {
+                delta:
+                    MessagesContentDelta::ThinkingDelta {
+                        thinking: Some(text),
+                    },
+            } if !text.is_empty() => {
+                reasoning_arrivals.push((now, text.clone()));
+                reasoning_text.push_str(&text);
+            }
+            MessagesStreamEvent::MessageStart { message } => {
+                usage = merge_messages_usage(usage, message.usage);
+            }
+            MessagesStreamEvent::MessageDelta {
+                usage: delta_usage, ..
+            } => {
+                usage = merge_messages_usage(usage, delta_usage);
+            }
+            MessagesStreamEvent::Error { error } => {
+                let message = error
+                    .message
+                    .as_deref()
+                    .unwrap_or("unknown Anthropic Messages API error");
+                return Err(anyhow!("Anthropic Messages API error: {}", message));
+            }
+            _ => {}
+        }
+    }
+
+    let end_time = Instant::now();
+    let request_end_unix_ns = unix_time_now_ns();
+
+    let usage_counts = usage.as_ref().and_then(token_counts_from_messages_usage);
     let token_counts = resolve_token_counts(
         request.use_server_token_count,
         usage_counts,
@@ -230,6 +330,38 @@ fn token_counts_from_responses_usage(usage: &ResponsesUsage) -> Option<TokenCoun
         reasoning,
         total,
     })
+}
+
+fn token_counts_from_messages_usage(usage: &MessagesUsage) -> Option<TokenCounts> {
+    let input = usage.input_tokens?;
+    let output = usage.output_tokens?;
+
+    Some(TokenCounts {
+        input,
+        output,
+        reasoning: 0,
+        total: input + output,
+    })
+}
+
+fn merge_messages_usage(
+    current: Option<MessagesUsage>,
+    update: Option<MessagesUsage>,
+) -> Option<MessagesUsage> {
+    match (current, update) {
+        (None, None) => None,
+        (Some(existing), None) => Some(existing),
+        (None, Some(new_usage)) => Some(new_usage),
+        (Some(mut existing), Some(new_usage)) => {
+            if new_usage.input_tokens.is_some() {
+                existing.input_tokens = new_usage.input_tokens;
+            }
+            if new_usage.output_tokens.is_some() {
+                existing.output_tokens = new_usage.output_tokens;
+            }
+            Some(existing)
+        }
+    }
 }
 
 fn resolve_token_counts(
@@ -390,7 +522,7 @@ fn unix_time_now_ns() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::client::ResponsesOutputTokensDetails;
+    use crate::client::openai::responses::ResponsesOutputTokensDetails;
     use async_openai::types::chat::CompletionTokensDetails;
     use std::time::{Duration, Instant};
 
@@ -815,5 +947,35 @@ mod tests {
         assert_eq!(counts.output, 3);
         assert_eq!(counts.reasoning, 1);
         assert_eq!(counts.total, 13);
+    }
+
+    #[test]
+    fn test_token_counts_from_messages_usage() {
+        let usage = MessagesUsage {
+            input_tokens: Some(12),
+            output_tokens: Some(8),
+        };
+
+        let counts = token_counts_from_messages_usage(&usage).expect("counts");
+        assert_eq!(counts.input, 12);
+        assert_eq!(counts.output, 8);
+        assert_eq!(counts.reasoning, 0);
+        assert_eq!(counts.total, 20);
+    }
+
+    #[test]
+    fn test_merge_messages_usage_prefers_latest_values() {
+        let current = MessagesUsage {
+            input_tokens: Some(10),
+            output_tokens: Some(1),
+        };
+        let update = MessagesUsage {
+            input_tokens: None,
+            output_tokens: Some(12),
+        };
+
+        let merged = merge_messages_usage(Some(current), Some(update)).expect("merged");
+        assert_eq!(merged.input_tokens, Some(10));
+        assert_eq!(merged.output_tokens, Some(12));
     }
 }

--- a/src/client/anthropic/messages.rs
+++ b/src/client/anthropic/messages.rs
@@ -1,0 +1,330 @@
+use anyhow::{Context, Result, anyhow};
+use futures::{Stream, StreamExt};
+use reqwest::Client as HttpClient;
+use serde::Deserialize;
+use std::pin::Pin;
+use std::str;
+
+const ANTHROPIC_MESSAGES_VERSION: &str = "2023-06-01";
+
+#[derive(Debug, Clone)]
+pub struct MessagesClient {
+    http: HttpClient,
+    base_url: String,
+    api_key: String,
+    version: String,
+}
+
+impl MessagesClient {
+    pub fn new(base_url: String, api_key: String) -> Self {
+        Self {
+            http: HttpClient::new(),
+            base_url,
+            api_key,
+            version: ANTHROPIC_MESSAGES_VERSION.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum MessagesStreamEvent {
+    #[serde(rename = "message_start")]
+    MessageStart { message: MessagesMessageStart },
+    #[serde(rename = "content_block_delta")]
+    ContentBlockDelta { delta: MessagesContentDelta },
+    #[serde(rename = "message_delta")]
+    MessageDelta {
+        #[serde(default)]
+        usage: Option<MessagesUsage>,
+    },
+    #[serde(rename = "error")]
+    Error { error: MessagesError },
+    #[serde(rename = "ping")]
+    Ping,
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum MessagesContentDelta {
+    #[serde(rename = "text_delta")]
+    TextDelta {
+        #[serde(default)]
+        text: Option<String>,
+    },
+    #[serde(rename = "thinking_delta")]
+    ThinkingDelta {
+        #[serde(default)]
+        thinking: Option<String>,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct MessagesUsage {
+    #[serde(default)]
+    pub input_tokens: Option<u32>,
+    #[serde(default)]
+    pub output_tokens: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MessagesMessageStart {
+    #[serde(default)]
+    pub usage: Option<MessagesUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MessagesError {
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+pub async fn create_messages_stream(
+    client: &MessagesClient,
+    model: &str,
+    prompt: &str,
+    max_tokens: u32,
+) -> Result<Pin<Box<dyn Stream<Item = Result<MessagesStreamEvent, anyhow::Error>> + Send>>> {
+    let url = build_messages_url(&client.base_url)?;
+    let request = serde_json::json!({
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": [
+            {
+                "role": "user",
+                "content": prompt
+            }
+        ],
+        "stream": true
+    });
+
+    let response = client
+        .http
+        .post(url)
+        .header("x-api-key", &client.api_key)
+        .header("anthropic-version", &client.version)
+        .header("accept", "text/event-stream")
+        .header("content-type", "application/json")
+        .json(&request)
+        .send()
+        .await
+        .map_err(|err| anyhow!("Anthropic Messages error: {}", err))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        let detail = body.trim();
+        let detail = if detail.is_empty() {
+            "empty response body"
+        } else {
+            detail
+        };
+        return Err(anyhow!(
+            "Anthropic Messages error (status {}): {}",
+            status,
+            detail
+        ));
+    }
+
+    let stream = response.bytes_stream();
+    Ok(Box::pin(messages_event_stream(stream)))
+}
+
+fn build_messages_url(base_url: &str) -> Result<String> {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.is_empty() {
+        return Err(anyhow!("Anthropic Messages base URL is empty"));
+    }
+    if trimmed.ends_with("/v1/messages") {
+        Ok(trimmed.to_string())
+    } else if trimmed.ends_with("/v1") {
+        Ok(format!("{trimmed}/messages"))
+    } else {
+        Ok(format!("{trimmed}/v1/messages"))
+    }
+}
+
+fn messages_event_stream<S, C>(
+    stream: S,
+) -> impl Stream<Item = Result<MessagesStreamEvent, anyhow::Error>> + Send
+where
+    S: Stream<Item = Result<C, reqwest::Error>> + Send + Unpin + 'static,
+    C: AsRef<[u8]> + Send + 'static,
+{
+    struct State<S> {
+        stream: S,
+        buffer: Vec<u8>,
+        done: bool,
+    }
+
+    futures::stream::try_unfold(
+        State {
+            stream,
+            buffer: Vec::new(),
+            done: false,
+        },
+        |mut state| async move {
+            loop {
+                if let Some((idx, delim_len)) = find_event_boundary(&state.buffer) {
+                    let event_bytes: Vec<u8> = state.buffer.drain(..idx).collect();
+                    state.buffer.drain(..delim_len);
+                    if let Some(data) = parse_sse_data(&event_bytes)? {
+                        let trimmed = data.trim();
+                        if trimmed.is_empty() || trimmed == "[DONE]" {
+                            continue;
+                        }
+                        let event = serde_json::from_str::<MessagesStreamEvent>(trimmed).map_err(
+                            |err| anyhow!("Anthropic Messages event parse error: {}", err),
+                        )?;
+                        return Ok(Some((event, state)));
+                    }
+                    continue;
+                }
+
+                if state.done {
+                    return Ok(None);
+                }
+
+                match state.stream.next().await {
+                    Some(Ok(chunk)) => state.buffer.extend_from_slice(chunk.as_ref()),
+                    Some(Err(err)) => {
+                        return Err(anyhow!("Anthropic Messages stream error: {}", err));
+                    }
+                    None => state.done = true,
+                }
+            }
+        },
+    )
+}
+
+fn parse_sse_data(event_bytes: &[u8]) -> Result<Option<String>> {
+    if event_bytes.is_empty() {
+        return Ok(None);
+    }
+    let text =
+        str::from_utf8(event_bytes).context("Anthropic Messages stream contained invalid UTF-8")?;
+    let mut data_lines = Vec::new();
+    for line in text.lines() {
+        if line.starts_with(':') || line.is_empty() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("data:") {
+            data_lines.push(rest.trim_start().to_string());
+        }
+    }
+    if data_lines.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(data_lines.join("\n")))
+    }
+}
+
+fn find_event_boundary(buffer: &[u8]) -> Option<(usize, usize)> {
+    let mut boundary: Option<(usize, usize)> = None;
+    if let Some(pos) = buffer.windows(2).position(|window| window == b"\n\n") {
+        boundary = Some((pos, 2));
+    }
+    if let Some(pos) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+        let replace = match boundary {
+            Some((current, _)) => pos < current,
+            None => true,
+        };
+        if replace {
+            boundary = Some((pos, 4));
+        }
+    }
+    boundary
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_messages_content_block_text_delta_deserialize() {
+        let event: MessagesStreamEvent = serde_json::from_str(
+            r#"{"type":"content_block_delta","delta":{"type":"text_delta","text":"hello"}}"#,
+        )
+        .expect("deserialize event");
+
+        match event {
+            MessagesStreamEvent::ContentBlockDelta { delta } => match delta {
+                MessagesContentDelta::TextDelta { text } => {
+                    assert_eq!(text.as_deref(), Some("hello"));
+                }
+                _ => panic!("unexpected delta variant"),
+            },
+            _ => panic!("unexpected event variant"),
+        }
+    }
+
+    #[test]
+    fn test_messages_content_block_thinking_delta_deserialize() {
+        let event: MessagesStreamEvent = serde_json::from_str(
+            r#"{"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"hmm"}}"#,
+        )
+        .expect("deserialize event");
+
+        match event {
+            MessagesStreamEvent::ContentBlockDelta { delta } => match delta {
+                MessagesContentDelta::ThinkingDelta { thinking } => {
+                    assert_eq!(thinking.as_deref(), Some("hmm"));
+                }
+                _ => panic!("unexpected delta variant"),
+            },
+            _ => panic!("unexpected event variant"),
+        }
+    }
+
+    #[test]
+    fn test_messages_message_delta_usage_deserialize() {
+        let event: MessagesStreamEvent = serde_json::from_str(
+            r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":3,"output_tokens":5}}"#,
+        )
+        .expect("deserialize event");
+
+        match event {
+            MessagesStreamEvent::MessageDelta { usage, .. } => {
+                let usage = usage.expect("usage");
+                assert_eq!(usage.input_tokens, Some(3));
+                assert_eq!(usage.output_tokens, Some(5));
+            }
+            _ => panic!("unexpected event variant"),
+        }
+    }
+
+    #[test]
+    fn test_messages_message_start_usage_deserialize() {
+        let event: MessagesStreamEvent = serde_json::from_str(
+            r#"{"type":"message_start","message":{"usage":{"input_tokens":7,"output_tokens":0}}}"#,
+        )
+        .expect("deserialize event");
+
+        match event {
+            MessagesStreamEvent::MessageStart { message } => {
+                let usage = message.usage.expect("usage");
+                assert_eq!(usage.input_tokens, Some(7));
+                assert_eq!(usage.output_tokens, Some(0));
+            }
+            _ => panic!("unexpected event variant"),
+        }
+    }
+
+    #[test]
+    fn test_messages_error_event_deserialize() {
+        let event: MessagesStreamEvent =
+            serde_json::from_str(r#"{"type":"error","error":{"message":"bad"}}"#)
+                .expect("deserialize event");
+
+        match event {
+            MessagesStreamEvent::Error { error } => {
+                assert_eq!(error.message.as_deref(), Some("bad"));
+            }
+            _ => panic!("unexpected event variant"),
+        }
+    }
+}

--- a/src/client/anthropic/messages.rs
+++ b/src/client/anthropic/messages.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result, anyhow};
 use futures::{Stream, StreamExt};
 use reqwest::Client as HttpClient;
 use serde::Deserialize;
+use serde_json::{Value, json};
 use std::pin::Pin;
 use std::str;
 
@@ -69,6 +70,16 @@ pub struct MessagesUsage {
     pub input_tokens: Option<u32>,
     #[serde(default)]
     pub output_tokens: Option<u32>,
+    #[serde(default)]
+    pub output_tokens_details: Option<MessagesOutputTokensDetails>,
+    #[serde(default)]
+    pub completion_tokens_details: Option<MessagesOutputTokensDetails>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct MessagesOutputTokensDetails {
+    #[serde(default)]
+    pub reasoning_tokens: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -88,19 +99,10 @@ pub async fn create_messages_stream(
     model: &str,
     prompt: &str,
     max_tokens: u32,
+    thinking_budget_tokens: Option<u32>,
 ) -> Result<Pin<Box<dyn Stream<Item = Result<MessagesStreamEvent, anyhow::Error>> + Send>>> {
     let url = build_messages_url(&client.base_url)?;
-    let request = serde_json::json!({
-        "model": model,
-        "max_tokens": max_tokens,
-        "messages": [
-            {
-                "role": "user",
-                "content": prompt
-            }
-        ],
-        "stream": true
-    });
+    let request = build_messages_request(model, prompt, max_tokens, thinking_budget_tokens);
 
     let response = client
         .http
@@ -132,6 +134,34 @@ pub async fn create_messages_stream(
 
     let stream = response.bytes_stream();
     Ok(Box::pin(messages_event_stream(stream)))
+}
+
+fn build_messages_request(
+    model: &str,
+    prompt: &str,
+    max_tokens: u32,
+    thinking_budget_tokens: Option<u32>,
+) -> Value {
+    let mut request = json!({
+        "model": model,
+        "max_tokens": max_tokens,
+        "messages": [
+            {
+                "role": "user",
+                "content": prompt
+            }
+        ],
+        "stream": true
+    });
+
+    if let Some(budget_tokens) = thinking_budget_tokens {
+        request["thinking"] = json!({
+            "type": "enabled",
+            "budget_tokens": budget_tokens
+        });
+    }
+
+    request
 }
 
 fn build_messages_url(base_url: &str) -> Result<String> {
@@ -326,5 +356,23 @@ mod tests {
             }
             _ => panic!("unexpected event variant"),
         }
+    }
+
+    #[test]
+    fn test_build_messages_request_without_thinking() {
+        let request = build_messages_request("test-model", "hello", 128, None);
+
+        assert_eq!(request["model"], "test-model");
+        assert_eq!(request["max_tokens"], 128);
+        assert_eq!(request["stream"], true);
+        assert!(request.get("thinking").is_none());
+    }
+
+    #[test]
+    fn test_build_messages_request_with_thinking() {
+        let request = build_messages_request("test-model", "hello", 1500, Some(1024));
+
+        assert_eq!(request["thinking"]["type"], "enabled");
+        assert_eq!(request["thinking"]["budget_tokens"], 1024);
     }
 }

--- a/src/client/anthropic/mod.rs
+++ b/src/client/anthropic/mod.rs
@@ -1,0 +1,1 @@
+pub mod messages;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,0 +1,28 @@
+pub mod anthropic;
+pub mod openai;
+
+use anthropic::messages::MessagesClient;
+use async_openai::Client;
+use async_openai::config::OpenAIConfig;
+
+#[derive(Debug)]
+pub enum ApiClient {
+    OpenAI(Box<Client<OpenAIConfig>>),
+    AnthropicMessages(Box<MessagesClient>),
+}
+
+impl ApiClient {
+    pub fn openai(&self) -> Option<&Client<OpenAIConfig>> {
+        match self {
+            ApiClient::OpenAI(client) => Some(client.as_ref()),
+            ApiClient::AnthropicMessages(_) => None,
+        }
+    }
+
+    pub fn anthropic_messages(&self) -> Option<&MessagesClient> {
+        match self {
+            ApiClient::AnthropicMessages(client) => Some(client.as_ref()),
+            ApiClient::OpenAI(_) => None,
+        }
+    }
+}

--- a/src/client/openai/chat.rs
+++ b/src/client/openai/chat.rs
@@ -1,0 +1,88 @@
+use anyhow::{Context, Result, anyhow};
+use async_openai::Client;
+use async_openai::config::OpenAIConfig;
+use async_openai::types::chat::{
+    ChatCompletionRequestUserMessageArgs, ChatCompletionStreamOptions, CompletionUsage,
+    CreateChatCompletionRequestArgs,
+};
+use futures::{Stream, StreamExt};
+use serde::Deserialize;
+use std::pin::Pin;
+
+#[derive(Debug, Deserialize)]
+pub struct StreamDelta {
+    pub content: Option<String>,
+    pub reasoning_content: Option<String>,
+    pub reasoning: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamChoice {
+    pub delta: StreamDelta,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct StreamChunk {
+    pub choices: Vec<StreamChoice>,
+    pub usage: Option<CompletionUsage>,
+}
+
+pub async fn create_chat_completion_stream(
+    client: &Client<OpenAIConfig>,
+    model: &str,
+    prompt: &str,
+    max_tokens: Option<u32>,
+    include_usage: bool,
+) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk, anyhow::Error>> + Send>>> {
+    let mut builder = CreateChatCompletionRequestArgs::default();
+    builder
+        .model(model)
+        .stream(true)
+        .messages([ChatCompletionRequestUserMessageArgs::default()
+            .content(prompt)
+            .build()
+            .context("Failed to build message")?
+            .into()]);
+
+    if let Some(tokens) = max_tokens {
+        builder.max_completion_tokens(tokens);
+    }
+
+    if include_usage {
+        builder.stream_options(ChatCompletionStreamOptions {
+            include_usage: Some(true),
+            include_obfuscation: None,
+        });
+    }
+
+    let request = builder.build().context("Failed to build request")?;
+
+    let stream = client
+        .chat()
+        .create_stream_byot::<_, StreamChunk>(request)
+        .await
+        .map_err(|err| anyhow!("OpenAI error: {:?}", err))?;
+
+    let mapped_stream =
+        stream.map(|chunk_result| chunk_result.map_err(|err| anyhow!("OpenAI error: {:?}", err)));
+
+    Ok(Box::pin(mapped_stream))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stream_chunk_usage_deserialize() {
+        let chunk: StreamChunk = serde_json::from_str(
+            r#"{"choices":[],"usage":{"prompt_tokens":4,"completion_tokens":6,"total_tokens":10}}"#,
+        )
+        .expect("deserialize chunk");
+
+        let usage = chunk.usage.expect("usage");
+        assert_eq!(usage.prompt_tokens, 4);
+        assert_eq!(usage.completion_tokens, 6);
+        assert_eq!(usage.total_tokens, 10);
+    }
+}

--- a/src/client/openai/mod.rs
+++ b/src/client/openai/mod.rs
@@ -1,0 +1,2 @@
+pub mod chat;
+pub mod responses;

--- a/src/client/openai/responses.rs
+++ b/src/client/openai/responses.rs
@@ -1,31 +1,10 @@
-use anyhow::{Context, Result, anyhow};
-use async_openai::types::chat::{
-    ChatCompletionRequestUserMessageArgs, ChatCompletionStreamOptions, CompletionUsage,
-    CreateChatCompletionRequestArgs,
-};
-use async_openai::{Client, config::OpenAIConfig};
+use anyhow::{Result, anyhow};
+use async_openai::Client;
+use async_openai::config::OpenAIConfig;
 use futures::{Stream, StreamExt};
 use serde::Deserialize;
 use serde_json::Value;
 use std::pin::Pin;
-
-#[derive(Debug, Deserialize)]
-pub struct StreamDelta {
-    pub content: Option<String>,
-    pub reasoning_content: Option<String>,
-    pub reasoning: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct StreamChoice {
-    pub delta: StreamDelta,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct StreamChunk {
-    pub choices: Vec<StreamChoice>,
-    pub usage: Option<CompletionUsage>,
-}
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
@@ -80,48 +59,6 @@ pub struct ResponsesOutputTokensDetails {
     pub reasoning_tokens: Option<u32>,
 }
 
-pub async fn create_chat_completion_stream(
-    client: &Client<OpenAIConfig>,
-    model: &str,
-    prompt: &str,
-    max_tokens: Option<u32>,
-    include_usage: bool,
-) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk, anyhow::Error>> + Send>>> {
-    let mut builder = CreateChatCompletionRequestArgs::default();
-    builder
-        .model(model)
-        .stream(true)
-        .messages([ChatCompletionRequestUserMessageArgs::default()
-            .content(prompt)
-            .build()
-            .context("Failed to build message")?
-            .into()]);
-
-    if let Some(tokens) = max_tokens {
-        builder.max_completion_tokens(tokens);
-    }
-
-    if include_usage {
-        builder.stream_options(ChatCompletionStreamOptions {
-            include_usage: Some(true),
-            include_obfuscation: None,
-        });
-    }
-
-    let request = builder.build().context("Failed to build request")?;
-
-    let stream = client
-        .chat()
-        .create_stream_byot::<_, StreamChunk>(request)
-        .await
-        .map_err(|err| anyhow!("OpenAI error: {:?}", err))?;
-
-    let mapped_stream =
-        stream.map(|chunk_result| chunk_result.map_err(|err| anyhow!("OpenAI error: {:?}", err)));
-
-    Ok(Box::pin(mapped_stream))
-}
-
 pub async fn create_responses_stream(
     client: &Client<OpenAIConfig>,
     model: &str,
@@ -153,19 +90,6 @@ pub async fn create_responses_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_stream_chunk_usage_deserialize() {
-        let chunk: StreamChunk = serde_json::from_str(
-            r#"{"choices":[],"usage":{"prompt_tokens":4,"completion_tokens":6,"total_tokens":10}}"#,
-        )
-        .expect("deserialize chunk");
-
-        let usage = chunk.usage.expect("usage");
-        assert_eq!(usage.prompt_tokens, 4);
-        assert_eq!(usage.completion_tokens, 6);
-        assert_eq!(usage.total_tokens, 10);
-    }
 
     #[test]
     fn test_output_text_delta_deserialize() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,8 @@ use args::{ApiType, Args, OutputFormat};
 use async_openai::{Client, config::OpenAIConfig};
 use benchmark::{BenchmarkRequest, BenchmarkResult, run_benchmark};
 use clap::Parser;
+use client::ApiClient;
+use client::anthropic::messages::MessagesClient;
 use futures::{StreamExt, stream::FuturesUnordered};
 use indicatif::{ProgressBar, ProgressStyle};
 use prompt::{PromptConfig, generate_prompt};
@@ -53,7 +55,7 @@ fn sample_max_tokens(mean: u32, stddev: u32) -> u32 {
 }
 
 async fn run_benchmark_task(
-    client: Arc<Client<OpenAIConfig>>,
+    client: Arc<ApiClient>,
     api_type: ApiType,
     request: BenchmarkRequest,
 ) -> Result<BenchmarkResult> {
@@ -74,17 +76,28 @@ async fn main() -> Result<()> {
         Err(err) => err.exit(),
     };
     let model = model.to_string();
+    args.validate().map_err(|err| anyhow::anyhow!("{err}"))?;
 
-    let mut openai_config = OpenAIConfig::new().with_api_base(url);
-    if let Some(api_key) = args.api_key.clone() {
-        openai_config = openai_config.with_api_key(api_key);
-    }
-    let client = Arc::new(Client::with_config(openai_config));
+    let api = args.api;
+    let api_key = args.api_key.clone();
+    let client = match api {
+        ApiType::Messages => Arc::new(ApiClient::AnthropicMessages(Box::new(MessagesClient::new(
+            url.to_string(),
+            api_key.clone().unwrap_or_default(),
+        )))),
+        ApiType::Chat | ApiType::Responses => {
+            let mut openai_config = OpenAIConfig::new().with_api_base(url);
+            if let Some(api_key) = api_key {
+                openai_config = openai_config.with_api_key(api_key);
+            }
+            Arc::new(ApiClient::OpenAI(Box::new(Client::with_config(
+                openai_config,
+            ))))
+        }
+    };
 
     let tokenizer = args.tokenizer.clone().unwrap_or_else(|| model.clone());
-    let api = args.api;
     let use_server_token_count = args.use_server_token_count;
-
     let overall_start = Instant::now();
     let overall_start_unix_ns = unix_time_now_ns();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn unix_time_now_ns() -> u64 {
         .unwrap_or_default()
 }
 
-fn sample_max_tokens(mean: u32, stddev: u32) -> u32 {
+fn sample_max_tokens(mean: u32, stddev: u32, min_exclusive: Option<u32>) -> u32 {
     if stddev == 0 {
         return mean.max(1);
     }
@@ -48,8 +48,12 @@ fn sample_max_tokens(mean: u32, stddev: u32) -> u32 {
 
     loop {
         let sample = dist.sample(&mut rng);
-        if sample >= 1.0 {
-            return sample.ceil() as u32;
+        if sample < 1.0 {
+            continue;
+        }
+        let tokens = sample.ceil() as u32;
+        if min_exclusive.is_none_or(|min| tokens > min) {
+            return tokens;
         }
     }
 }
@@ -151,14 +155,20 @@ async fn main() -> Result<()> {
         let prompt_clone = prompt.clone();
         let client_clone = client.clone();
         let tokenizer_clone = tokenizer.clone();
+        let min_output_tokens = if matches!(api, ApiType::Messages) {
+            args.thinking_budget_tokens
+        } else {
+            None
+        };
         let max_tokens = args
             .mean_output_tokens
-            .map(|mean| sample_max_tokens(mean, args.stddev_output_tokens));
+            .map(|mean| sample_max_tokens(mean, args.stddev_output_tokens, min_output_tokens));
 
         let request = BenchmarkRequest {
             model: model_name,
             prompt: prompt_clone,
             max_tokens,
+            thinking_budget_tokens: args.thinking_budget_tokens,
             tokenizer: tokenizer_clone,
             use_server_token_count,
         };
@@ -200,14 +210,20 @@ async fn main() -> Result<()> {
                     let prompt_clone = prompt.clone();
                     let client_clone = client.clone();
                     let tokenizer_clone = tokenizer.clone();
-                    let max_tokens = args
-                        .mean_output_tokens
-                        .map(|mean| sample_max_tokens(mean, args.stddev_output_tokens));
+                    let min_output_tokens = if matches!(api, ApiType::Messages) {
+                        args.thinking_budget_tokens
+                    } else {
+                        None
+                    };
+                    let max_tokens = args.mean_output_tokens.map(|mean| {
+                        sample_max_tokens(mean, args.stddev_output_tokens, min_output_tokens)
+                    });
 
                     let request = BenchmarkRequest {
                         model: model_name,
                         prompt: prompt_clone,
                         max_tokens,
+                        thinking_budget_tokens: args.thinking_budget_tokens,
                         tokenizer: tokenizer_clone,
                         use_server_token_count,
                     };

--- a/src/output.rs
+++ b/src/output.rs
@@ -593,7 +593,7 @@ fn build_summary(
         .collect();
 
     BenchmarkSummary {
-        version: "2026-02-19".to_string(),
+        version: "2026-05-02".to_string(),
         schema_version: "2.0".to_string(),
         llmnop_version: env!("CARGO_PKG_VERSION").to_string(),
         benchmark_id: run_id.to_string(),


### PR DESCRIPTION
## Summary

- Add `--api messages` to benchmark Anthropic Messages API endpoints
- Require `--mean-output-tokens` for messages API (needed for `max_tokens` in request)
- Refactor client module into `openai` and `anthropic` submodules