### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [0.9.0]
+
 ### Changed
 
 - Benchmark JSON output now always writes to the platform app data/state directory for llmnop instead of the current working directory. ([#51](https://github.com/jpreagan/llmnop/pull/51))
@@ -21,7 +23,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - Removed `--results-dir`; output location is now managed automatically. ([#51](https://github.com/jpreagan/llmnop/pull/51))
 
-## [0.8.0] - 2026-02-18
+## [0.8.0]
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,7 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llmnop"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llmnop"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A command-line tool for benchmarking the performance of LLM inference endpoints."
@@ -10,7 +10,7 @@ repository = "https://github.com/jpreagan/llmnop"
 readme = "README.md"
 keywords = ["llm", "benchmark", "performance", "openai", "inference"]
 categories = ["command-line-utilities", "development-tools"]
-exclude = ["assets/*", ".claude/*", ".github/*", "AGENTS.md", "CLAUDE.md", "dist-workspace.toml"]
+exclude = ["assets/*", ".agents/*", ".claude/*", ".github/*", "AGENTS.md", "CLAUDE.md", "dist-workspace.toml"]
 
 [dependencies]
 anyhow = "1.0.97"


### PR DESCRIPTION
## Summary
- bump crate version to 0.9.0
- promote unreleased changelog entries into 0.9.0
- exclude .agents files from published crate package