### PR TITLE
fix(cli): prevent ambient credential leakage without --api-key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Add Anthropic Messages API support via `--api messages`. ([#36](https://github.com/jpreagan/llmnop/pull/36))
 - Add `--thinking-budget-tokens` for Anthropic Messages API extended thinking. ([#36](https://github.com/jpreagan/llmnop/pull/36))
 
+### Security
+
+- Prevent ambient `OPENAI_API_KEY` from being sent to benchmark endpoints when `--api-key` is omitted.
+
 ## [0.9.0]
 
 ### Changed

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,17 +83,14 @@ async fn main() -> Result<()> {
     args.validate().map_err(|err| anyhow::anyhow!("{err}"))?;
 
     let api = args.api;
-    let api_key = args.api_key.clone();
+    let api_key = args.api_key.clone().unwrap_or_default();
     let client = match api {
         ApiType::Messages => Arc::new(ApiClient::AnthropicMessages(Box::new(MessagesClient::new(
             url.to_string(),
-            api_key.clone().unwrap_or_default(),
+            api_key.clone(),
         )))),
         ApiType::Chat | ApiType::Responses => {
-            let mut openai_config = OpenAIConfig::new().with_api_base(url);
-            if let Some(api_key) = api_key {
-                openai_config = openai_config.with_api_key(api_key);
-            }
+            let openai_config = OpenAIConfig::new().with_api_base(url).with_api_key(api_key);
             Arc::new(ApiClient::OpenAI(Box::new(Client::with_config(
                 openai_config,
             ))))


### PR DESCRIPTION
### Motivation
- Make sure an omitted `--api-key` does not cause `async-openai` to use ambient `OPENAI_API_KEY`/`OPENAI_ADMIN_KEY` and accidentally forward real credentials to a user-supplied `--url`.

### Description
- Always set the API key on the client config in `src/main.rs` by using `args.api_key.clone().unwrap_or_default()` and calling `with_api_key(...)`, so an explicit empty key overrides any environment-derived defaults.

### Testing
- Ran `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test`, and all commands completed successfully (unit tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65fde62f88332b851d4307d0f4b25)