### PR TITLE
fix(output): separate provider usage metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - Add Anthropic Messages API support via `--api messages`. ([#36](https://github.com/jpreagan/llmnop/pull/36))
 - Add `--thinking-budget-tokens` for Anthropic Messages API extended thinking. ([#36](https://github.com/jpreagan/llmnop/pull/36))
+- Add separate provider usage token metrics in JSON output while preserving measured output/reasoning token metrics.
+
+### Changed
+
+- `--use-server-token-count` now requests provider usage reporting instead of replacing llmnop's measured token metrics.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -107,14 +107,14 @@ Control input and output token counts to simulate realistic workloads:
 
 ### Tokenization
 
-By default, llmnop uses a local Hugging Face tokenizer matching `--model` to count tokens.
+By default, llmnop uses a local Hugging Face tokenizer matching `--model` to count measured token metrics.
 
 | Flag                       | Description                                                               |
 | -------------------------- | ------------------------------------------------------------------------- |
 | `--tokenizer`              | Use a different HF tokenizer (when model name doesn't match Hugging Face) |
-| `--use-server-token-count` | Use server-reported usage instead of local tokenization                   |
+| `--use-server-token-count` | Request provider-reported usage and record it separately                 |
 
-Use `--use-server-token-count` when you trust the server's token counts and want to avoid downloading tokenizer files. The server must return usage data or llmnop will error.
+Primary token metrics preserve llmnop's measured semantics: `output_token_count` is visible answer tokens, `reasoning_token_count` is reasoning/thinking tokens, and `output_sequence_length` is their sum. Provider usage fields such as `usage_input_tokens`, `usage_output_tokens`, `usage_total_tokens`, and `usage_reasoning_tokens` are recorded separately when available because provider `usage` may be aggregate or unsplit.
 
 ### Output
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -137,7 +137,7 @@ pub struct Args {
 
     #[arg(
         long,
-        help = "Use server-reported token usage for metrics",
+        help = "Request provider-reported token usage and record it separately",
         help_heading = "Tokenization"
     )]
     pub use_server_token_count: bool,

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -28,8 +28,17 @@ pub struct BenchmarkResult {
     pub inter_token_latency_s: f64,
     pub inter_event_latency_s: f64,
     pub total_tokens: u32,
+    pub provider_usage: Option<ProviderUsage>,
     pub request_start_unix_ns: u64,
     pub request_end_unix_ns: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProviderUsage {
+    pub input_tokens: Option<u32>,
+    pub output_tokens: Option<u32>,
+    pub total_tokens: Option<u32>,
+    pub reasoning_tokens: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -47,6 +56,12 @@ struct TokenCounts {
     output: u32,
     reasoning: u32,
     total: u32,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RequestTiming {
+    start_unix_ns: u64,
+    end_unix_ns: u64,
 }
 
 pub async fn run_benchmark(
@@ -127,10 +142,8 @@ async fn run_chat_benchmark(
     let end_time = Instant::now();
     let request_end_unix_ns = unix_time_now_ns();
 
-    let usage_counts = usage.as_ref().map(token_counts_from_chat_usage);
-    let token_counts = resolve_token_counts(
-        request.use_server_token_count,
-        usage_counts,
+    let provider_usage = usage.as_ref().map(provider_usage_from_chat_usage);
+    let token_counts = compute_token_counts(
         &request.prompt,
         &generated_text,
         &reasoning_text,
@@ -143,8 +156,11 @@ async fn run_chat_benchmark(
         &content_arrivals,
         &reasoning_arrivals,
         &token_counts,
-        request_start_unix_ns,
-        request_end_unix_ns,
+        provider_usage,
+        RequestTiming {
+            start_unix_ns: request_start_unix_ns,
+            end_unix_ns: request_end_unix_ns,
+        },
     ))
 }
 
@@ -197,10 +213,8 @@ async fn run_responses_benchmark(
     let end_time = Instant::now();
     let request_end_unix_ns = unix_time_now_ns();
 
-    let usage_counts = usage.as_ref().and_then(token_counts_from_responses_usage);
-    let token_counts = resolve_token_counts(
-        request.use_server_token_count,
-        usage_counts,
+    let provider_usage = usage.as_ref().map(provider_usage_from_responses_usage);
+    let token_counts = compute_token_counts(
         &request.prompt,
         &generated_text,
         &reasoning_text,
@@ -213,8 +227,11 @@ async fn run_responses_benchmark(
         &content_arrivals,
         &reasoning_arrivals,
         &token_counts,
-        request_start_unix_ns,
-        request_end_unix_ns,
+        provider_usage,
+        RequestTiming {
+            start_unix_ns: request_start_unix_ns,
+            end_unix_ns: request_end_unix_ns,
+        },
     ))
 }
 
@@ -296,15 +313,8 @@ async fn run_messages_benchmark(
         ));
     }
 
-    let use_server_token_count = should_use_messages_server_token_count(
-        request.use_server_token_count,
-        usage.as_ref(),
-        &reasoning_text,
-    );
-    let usage_counts = usage.as_ref().and_then(token_counts_from_messages_usage);
-    let token_counts = resolve_token_counts(
-        use_server_token_count,
-        usage_counts,
+    let provider_usage = usage.as_ref().map(provider_usage_from_messages_usage);
+    let token_counts = compute_token_counts(
         &request.prompt,
         &generated_text,
         &reasoning_text,
@@ -317,58 +327,49 @@ async fn run_messages_benchmark(
         &content_arrivals,
         &reasoning_arrivals,
         &token_counts,
-        request_start_unix_ns,
-        request_end_unix_ns,
+        provider_usage,
+        RequestTiming {
+            start_unix_ns: request_start_unix_ns,
+            end_unix_ns: request_end_unix_ns,
+        },
     ))
 }
 
-fn token_counts_from_chat_usage(usage: &CompletionUsage) -> TokenCounts {
-    let reasoning = usage
+fn provider_usage_from_chat_usage(usage: &CompletionUsage) -> ProviderUsage {
+    let reasoning_tokens = usage
         .completion_tokens_details
         .as_ref()
-        .and_then(|details| details.reasoning_tokens)
-        .unwrap_or(0);
-    let output = usage.completion_tokens.saturating_sub(reasoning);
+        .and_then(|details| details.reasoning_tokens);
 
-    TokenCounts {
-        input: usage.prompt_tokens,
-        output,
-        reasoning,
-        total: usage.total_tokens,
+    ProviderUsage {
+        input_tokens: Some(usage.prompt_tokens),
+        output_tokens: Some(usage.completion_tokens),
+        total_tokens: Some(usage.total_tokens),
+        reasoning_tokens,
     }
 }
 
-fn token_counts_from_responses_usage(usage: &ResponsesUsage) -> Option<TokenCounts> {
-    let input = usage.input_tokens?;
-    let output_total = usage.output_tokens?;
-    let reasoning = usage
+fn provider_usage_from_responses_usage(usage: &ResponsesUsage) -> ProviderUsage {
+    let reasoning_tokens = usage
         .output_tokens_details
         .as_ref()
-        .and_then(|details| details.reasoning_tokens)
-        .unwrap_or(0);
-    let output = output_total.saturating_sub(reasoning);
-    let total = usage.total_tokens.unwrap_or(input + output_total);
+        .and_then(|details| details.reasoning_tokens);
 
-    Some(TokenCounts {
-        input,
-        output,
-        reasoning,
-        total,
-    })
+    ProviderUsage {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        total_tokens: usage.total_tokens,
+        reasoning_tokens,
+    }
 }
 
-fn token_counts_from_messages_usage(usage: &MessagesUsage) -> Option<TokenCounts> {
-    let input = usage.input_tokens?;
-    let output_total = usage.output_tokens?;
-    let reasoning = messages_usage_reasoning_tokens(usage).unwrap_or(0);
-    let output = output_total.saturating_sub(reasoning);
-
-    Some(TokenCounts {
-        input,
-        output,
-        reasoning,
-        total: input + output_total,
-    })
+fn provider_usage_from_messages_usage(usage: &MessagesUsage) -> ProviderUsage {
+    ProviderUsage {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        total_tokens: None,
+        reasoning_tokens: messages_usage_reasoning_tokens(usage),
+    }
 }
 
 fn messages_usage_reasoning_tokens(usage: &MessagesUsage) -> Option<u32> {
@@ -382,15 +383,6 @@ fn messages_usage_reasoning_tokens(usage: &MessagesUsage) -> Option<u32> {
                 .as_ref()
                 .and_then(|details| details.reasoning_tokens)
         })
-}
-
-fn should_use_messages_server_token_count(
-    requested: bool,
-    usage: Option<&MessagesUsage>,
-    reasoning_text: &str,
-) -> bool {
-    requested
-        && (reasoning_text.is_empty() || usage.and_then(messages_usage_reasoning_tokens).is_some())
 }
 
 fn merge_messages_usage(
@@ -416,21 +408,6 @@ fn merge_messages_usage(
             }
             Some(existing)
         }
-    }
-}
-
-fn resolve_token_counts(
-    use_server_token_count: bool,
-    usage_counts: Option<TokenCounts>,
-    prompt: &str,
-    generated_text: &str,
-    reasoning_text: &str,
-    tokenizer: &str,
-) -> Result<TokenCounts> {
-    if use_server_token_count {
-        usage_counts.ok_or_else(|| anyhow!("server did not return token usage"))
-    } else {
-        compute_token_counts(prompt, generated_text, reasoning_text, tokenizer)
     }
 }
 
@@ -470,8 +447,11 @@ fn process_benchmark_data(
         content_arrivals,
         reasoning_arrivals,
         tokens,
-        0,
-        0,
+        None,
+        RequestTiming {
+            start_unix_ns: 0,
+            end_unix_ns: 0,
+        },
     )
 }
 
@@ -481,8 +461,8 @@ fn process_benchmark_data_with_timestamps(
     content_arrivals: &[(Instant, String)],
     reasoning_arrivals: &[(Instant, String)],
     tokens: &TokenCounts,
-    request_start_unix_ns: u64,
-    request_end_unix_ns: u64,
+    provider_usage: Option<ProviderUsage>,
+    timing: RequestTiming,
 ) -> BenchmarkResult {
     let first_content_time = content_arrivals.first().map(|(t, _)| *t);
     let first_reasoning_time = reasoning_arrivals.first().map(|(t, _)| *t);
@@ -559,8 +539,9 @@ fn process_benchmark_data_with_timestamps(
         inter_token_latency_s,
         inter_event_latency_s,
         total_tokens: tokens.total,
-        request_start_unix_ns,
-        request_end_unix_ns,
+        provider_usage,
+        request_start_unix_ns: timing.start_unix_ns,
+        request_end_unix_ns: timing.end_unix_ns,
     }
 }
 
@@ -981,15 +962,15 @@ mod tests {
             }),
         };
 
-        let counts = token_counts_from_chat_usage(&usage);
-        assert_eq!(counts.input, 12);
-        assert_eq!(counts.output, 5);
-        assert_eq!(counts.reasoning, 3);
-        assert_eq!(counts.total, 20);
+        let provider_usage = provider_usage_from_chat_usage(&usage);
+        assert_eq!(provider_usage.input_tokens, Some(12));
+        assert_eq!(provider_usage.output_tokens, Some(8));
+        assert_eq!(provider_usage.reasoning_tokens, Some(3));
+        assert_eq!(provider_usage.total_tokens, Some(20));
     }
 
     #[test]
-    fn test_token_counts_from_responses_usage_with_reasoning() {
+    fn test_provider_usage_from_responses_usage_with_reasoning() {
         let usage = ResponsesUsage {
             input_tokens: Some(9),
             output_tokens: Some(4),
@@ -999,15 +980,15 @@ mod tests {
             }),
         };
 
-        let counts = token_counts_from_responses_usage(&usage).expect("counts");
-        assert_eq!(counts.input, 9);
-        assert_eq!(counts.output, 3);
-        assert_eq!(counts.reasoning, 1);
-        assert_eq!(counts.total, 13);
+        let provider_usage = provider_usage_from_responses_usage(&usage);
+        assert_eq!(provider_usage.input_tokens, Some(9));
+        assert_eq!(provider_usage.output_tokens, Some(4));
+        assert_eq!(provider_usage.reasoning_tokens, Some(1));
+        assert_eq!(provider_usage.total_tokens, None);
     }
 
     #[test]
-    fn test_token_counts_from_messages_usage() {
+    fn test_provider_usage_from_messages_usage() {
         let usage = MessagesUsage {
             input_tokens: Some(12),
             output_tokens: Some(8),
@@ -1015,15 +996,15 @@ mod tests {
             completion_tokens_details: None,
         };
 
-        let counts = token_counts_from_messages_usage(&usage).expect("counts");
-        assert_eq!(counts.input, 12);
-        assert_eq!(counts.output, 8);
-        assert_eq!(counts.reasoning, 0);
-        assert_eq!(counts.total, 20);
+        let provider_usage = provider_usage_from_messages_usage(&usage);
+        assert_eq!(provider_usage.input_tokens, Some(12));
+        assert_eq!(provider_usage.output_tokens, Some(8));
+        assert_eq!(provider_usage.reasoning_tokens, None);
+        assert_eq!(provider_usage.total_tokens, None);
     }
 
     #[test]
-    fn test_token_counts_from_messages_usage_with_reasoning() {
+    fn test_provider_usage_from_messages_usage_with_reasoning() {
         let usage = MessagesUsage {
             input_tokens: Some(12),
             output_tokens: Some(8),
@@ -1033,45 +1014,11 @@ mod tests {
             completion_tokens_details: None,
         };
 
-        let counts = token_counts_from_messages_usage(&usage).expect("counts");
-        assert_eq!(counts.input, 12);
-        assert_eq!(counts.output, 5);
-        assert_eq!(counts.reasoning, 3);
-        assert_eq!(counts.total, 20);
-    }
-
-    #[test]
-    fn test_messages_server_counts_disabled_for_aggregate_reasoning_stream() {
-        let usage = MessagesUsage {
-            input_tokens: Some(12),
-            output_tokens: Some(8),
-            output_tokens_details: None,
-            completion_tokens_details: None,
-        };
-
-        assert!(!should_use_messages_server_token_count(
-            true,
-            Some(&usage),
-            "thinking"
-        ));
-    }
-
-    #[test]
-    fn test_messages_server_counts_allowed_for_reasoning_split() {
-        let usage = MessagesUsage {
-            input_tokens: Some(12),
-            output_tokens: Some(8),
-            output_tokens_details: Some(MessagesOutputTokensDetails {
-                reasoning_tokens: Some(3),
-            }),
-            completion_tokens_details: None,
-        };
-
-        assert!(should_use_messages_server_token_count(
-            true,
-            Some(&usage),
-            "thinking"
-        ));
+        let provider_usage = provider_usage_from_messages_usage(&usage);
+        assert_eq!(provider_usage.input_tokens, Some(12));
+        assert_eq!(provider_usage.output_tokens, Some(8));
+        assert_eq!(provider_usage.reasoning_tokens, Some(3));
+        assert_eq!(provider_usage.total_tokens, None);
     }
 
     #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -108,6 +108,14 @@ pub struct BenchmarkSummary {
     pub output_token_count: MetricStats,
     pub reasoning_token_count: MetricStats,
     pub output_sequence_length: MetricStats,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage_input_tokens: Option<MetricStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage_output_tokens: Option<MetricStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage_total_tokens: Option<MetricStats>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage_reasoning_tokens: Option<MetricStats>,
 
     pub total_input_tokens: MetricStats,
     pub total_output_tokens: MetricStats,
@@ -443,6 +451,32 @@ pub fn write_results_json(
                     "output_sequence_length".to_string(),
                     metric_value_u64((br.output_tokens + br.reasoning_tokens) as u64, "tokens"),
                 );
+                if let Some(usage) = &br.provider_usage {
+                    if let Some(tokens) = usage.input_tokens {
+                        metrics.insert(
+                            "usage_input_tokens".to_string(),
+                            metric_value_u64(tokens as u64, "tokens"),
+                        );
+                    }
+                    if let Some(tokens) = usage.output_tokens {
+                        metrics.insert(
+                            "usage_output_tokens".to_string(),
+                            metric_value_u64(tokens as u64, "tokens"),
+                        );
+                    }
+                    if let Some(tokens) = usage.total_tokens {
+                        metrics.insert(
+                            "usage_total_tokens".to_string(),
+                            metric_value_u64(tokens as u64, "tokens"),
+                        );
+                    }
+                    if let Some(tokens) = usage.reasoning_tokens {
+                        metrics.insert(
+                            "usage_reasoning_tokens".to_string(),
+                            metric_value_u64(tokens as u64, "tokens"),
+                        );
+                    }
+                }
 
                 let record = RequestRecord {
                     metadata: RequestMetadata {
@@ -540,6 +574,10 @@ fn build_summary(
     let mut out_tokens = Vec::new();
     let mut reasoning_tokens = Vec::new();
     let mut output_sequence_tokens = Vec::new();
+    let mut usage_input_tokens = Vec::new();
+    let mut usage_output_tokens = Vec::new();
+    let mut usage_total_tokens = Vec::new();
+    let mut usage_reasoning_tokens = Vec::new();
 
     for br in successful_results {
         request_latency_ms.push(br.total_latency.as_secs_f64() * 1000.0);
@@ -554,6 +592,20 @@ fn build_summary(
         out_tokens.push(br.output_tokens as f64);
         reasoning_tokens.push(br.reasoning_tokens as f64);
         output_sequence_tokens.push((br.output_tokens + br.reasoning_tokens) as f64);
+        if let Some(usage) = &br.provider_usage {
+            if let Some(tokens) = usage.input_tokens {
+                usage_input_tokens.push(tokens as f64);
+            }
+            if let Some(tokens) = usage.output_tokens {
+                usage_output_tokens.push(tokens as f64);
+            }
+            if let Some(tokens) = usage.total_tokens {
+                usage_total_tokens.push(tokens as f64);
+            }
+            if let Some(tokens) = usage.reasoning_tokens {
+                usage_reasoning_tokens.push(tokens as f64);
+            }
+        }
     }
 
     let completed_requests = successful_results.len();
@@ -593,7 +645,7 @@ fn build_summary(
         .collect();
 
     BenchmarkSummary {
-        version: "2026-05-02".to_string(),
+        version: "2026-05-03".to_string(),
         schema_version: "2.0".to_string(),
         llmnop_version: env!("CARGO_PKG_VERSION").to_string(),
         benchmark_id: run_id.to_string(),
@@ -636,6 +688,10 @@ fn build_summary(
         output_token_count: metric_stats_from_values(&out_tokens, "tokens"),
         reasoning_token_count: metric_stats_from_values(&reasoning_tokens, "tokens"),
         output_sequence_length: metric_stats_from_values(&output_sequence_tokens, "tokens"),
+        usage_input_tokens: metric_stats_optional(&usage_input_tokens, "tokens"),
+        usage_output_tokens: metric_stats_optional(&usage_output_tokens, "tokens"),
+        usage_total_tokens: metric_stats_optional(&usage_total_tokens, "tokens"),
+        usage_reasoning_tokens: metric_stats_optional(&usage_reasoning_tokens, "tokens"),
         total_input_tokens: metric_stats_avg_only("tokens", total_input_tokens as f64),
         total_output_tokens: metric_stats_avg_only("tokens", total_output_tokens as f64),
         total_reasoning_tokens: metric_stats_avg_only("tokens", total_reasoning_tokens as f64),
@@ -748,6 +804,14 @@ fn metric_stats_from_values(values: &[f64], unit: &str) -> MetricStats {
         min: Some(stats.min),
         max: Some(stats.max),
         std: Some(stats.stddev),
+    }
+}
+
+fn metric_stats_optional(values: &[f64], unit: &str) -> Option<MetricStats> {
+    if values.is_empty() {
+        None
+    } else {
+        Some(metric_stats_from_values(values, unit))
     }
 }
 
@@ -949,6 +1013,12 @@ mod tests {
             inter_token_latency_s: 0.01,
             inter_event_latency_s: 0.02,
             total_tokens: 700,
+            provider_usage: Some(crate::benchmark::ProviderUsage {
+                input_tokens: Some(550),
+                output_tokens: Some(150),
+                total_tokens: Some(700),
+                reasoning_tokens: Some(30),
+            }),
             request_start_unix_ns: 1_700_000_000_000_000_000,
             request_end_unix_ns: 1_700_000_000_900_000_000,
         }];
@@ -969,11 +1039,16 @@ mod tests {
         );
 
         assert_eq!(summary.schema_version, "2.0");
+        assert_eq!(summary.version, "2026-05-03");
         assert_eq!(summary.request_latency.unit, "ms");
         assert_eq!(
             summary.output_token_throughput_per_request.unit,
             "tokens/sec/request"
         );
         assert!(summary.time_to_first_output_token.is_some());
+        assert_eq!(
+            summary.usage_output_tokens.and_then(|stats| stats.avg),
+            Some(150.0)
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Separate provider-reported usage metrics from llmnop's measured token metrics
- Keep `output_token_count`, `reasoning_token_count`, and `output_sequence_length` based on streamed deltas
- Add `usage_*` JSON fields for provider usage when available

Fixes #60.