### PR TITLE
docs(install): add llmnop.xyz endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It's a single binary with no dependencies, just download and run. Use it to comp
 Use the installer:
 
 ```bash
-curl -sSfL https://github.com/jpreagan/llmnop/releases/latest/download/llmnop-installer.sh | sh
+curl -sSfL https://llmnop.xyz/install.sh | sh
 ```
 
 It places `llmnop` in `~/.local/bin`. Make sure that's on your `PATH`.

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+llmnop.xyz

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu
+
+installer_url="https://github.com/jpreagan/llmnop/releases/latest/download/llmnop-installer.sh"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/llmnop.XXXXXX")"
+installer="$tmp_dir/llmnop-installer.sh"
+
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+trap cleanup 0 HUP INT TERM
+
+curl --proto '=https' --tlsv1.2 -sSfL "$installer_url" -o "$installer"
+sh "$installer" "$@"


### PR DESCRIPTION
## Summary

Add `https://llmnop.xyz/install.sh` as a stable bootstrap for the latest cargo-dist installer and use it in the README. The bootstrap downloads the official GitHub Release installer to a temporary file before running it and passes shell syntax and download checks.