### PR TITLE
feat(workload): generate exact sonnet workloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+
+- Support local tokenizer JSON files through `--tokenizer`. ([#69](https://github.com/jpreagan/llmnop/pull/69))
+
+### Changed
+
+- Rename `--mean-input-tokens` to `--input-tokens`, `--stddev-input-tokens` to `--input-tokens-stddev`, `--mean-output-tokens` to `--output-cap`, `--stddev-output-tokens` to `--output-cap-stddev`, and `--thinking-budget-tokens` to `--thinking-budget`. ([#69](https://github.com/jpreagan/llmnop/pull/69))
+
+### Fixed
+
+- Ensure generated prompts match their requested token counts or fail explicitly when that target cannot be met. ([#69](https://github.com/jpreagan/llmnop/pull/69))
+
 ## [0.10.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ brew upgrade llmnop
 llmnop --url http://localhost:8000/v1 \
   --api-key token-abc123 \
   --model Qwen/Qwen3-4B-Instruct-2507 \
-  --mean-output-tokens 150
+  --output-cap 150
 ```
 
 Results print to stdout and save under the llmnop app results directory:
@@ -92,14 +92,14 @@ Control input and output token counts to simulate realistic workloads:
 
 | Flag                       | Default | Description                                               |
 | -------------------------- | ------- | --------------------------------------------------------- |
-| `--mean-input-tokens`      | 550     | Target prompt length in tokens                            |
-| `--stddev-input-tokens`    | 0       | Add variance to input length                              |
-| `--mean-output-tokens`     | none    | Mean output token cap to request                          |
-| `--stddev-output-tokens`   | 0       | Add variance to output length                             |
-| `--thinking-budget-tokens` | none    | Enable Anthropic Messages thinking with this token budget |
+| `--input-tokens`      | 550     | Target prompt length in tokens                            |
+| `--input-tokens-stddev`    | 0       | Add variance to input length                              |
+| `--output-cap`     | none    | Mean output token cap to request                          |
+| `--output-cap-stddev`   | 0       | Add variance to output length                             |
+| `--thinking-budget` | none    | Enable Anthropic Messages thinking with this token budget |
 
-For `--api messages`, `--mean-output-tokens` is required so llmnop can set `max_tokens` in the request.
-When `--thinking-budget-tokens` is set, it must be at least 1024 and smaller than `--mean-output-tokens`.
+For `--api messages`, `--output-cap` is required so llmnop can set `max_tokens` in the request.
+When `--thinking-budget` is set, it must be at least 1024 and smaller than `--output-cap`.
 
 ### Load Testing
 
@@ -144,7 +144,7 @@ llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
 ```bash
 llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
   --model Qwen/Qwen3-4B-Instruct-2507 \
-  --mean-output-tokens 150
+  --output-cap 150
 ```
 
 **Responses API:**
@@ -159,7 +159,7 @@ llmnop --api responses --url http://localhost:8000/v1 --api-key token-abc123 \
 ```bash
 llmnop --api messages --url http://localhost:8000/v1 --api-key token-abc123 \
   --model Qwen/Qwen3.6-27B \
-  --mean-output-tokens 4096
+  --output-cap 4096
 ```
 
 **JSON stdout for `jq` pipelines:**
@@ -212,3 +212,7 @@ The summary includes statistical breakdowns for latency and token metrics. `indi
 ## License
 
 [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+Sonnet prompts use a fresh random window from the tokenized Shakespeare corpus.
+Prompt text must re-tokenize to its sampled target; generation fails if repair cannot achieve that length.
+The tokenizer may be a Hugging Face identifier or a local tokenizer JSON file.

--- a/src/args.rs
+++ b/src/args.rs
@@ -22,7 +22,6 @@ pub enum OutputFormat {
 #[cfg(feature = "self-update")]
 #[derive(Debug, Subcommand)]
 pub enum Command {
-    /// Update llmnop (standalone installs only)
     Update,
 }
 
@@ -40,7 +39,6 @@ pub struct Args {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    // Endpoint
     #[arg(
         long,
         help = "Base URL (e.g., http://localhost:8000/v1)",
@@ -63,14 +61,13 @@ pub struct Args {
     )]
     pub api: ApiType,
 
-    // Request Shaping
     #[arg(
         long,
         default_value = "550",
         help = "Target input length",
         help_heading = "Request Shaping"
     )]
-    pub mean_input_tokens: u32,
+    pub input_tokens: u32,
 
     #[arg(
         long,
@@ -78,14 +75,14 @@ pub struct Args {
         help = "Input length variance",
         help_heading = "Request Shaping"
     )]
-    pub stddev_input_tokens: u32,
+    pub input_tokens_stddev: u32,
 
     #[arg(
         long,
         help = "Mean output token cap to request [default: none]",
         help_heading = "Request Shaping"
     )]
-    pub mean_output_tokens: Option<u32>,
+    pub output_cap: Option<u32>,
 
     #[arg(
         long,
@@ -93,16 +90,15 @@ pub struct Args {
         help = "Output length variance",
         help_heading = "Request Shaping"
     )]
-    pub stddev_output_tokens: u32,
+    pub output_cap_stddev: u32,
 
     #[arg(
         long,
         help = "Enable Anthropic Messages thinking with this token budget",
         help_heading = "Request Shaping"
     )]
-    pub thinking_budget_tokens: Option<u32>,
+    pub thinking_budget: Option<u32>,
 
-    // Load Testing
     #[arg(
         long,
         default_value = "10",
@@ -127,7 +123,6 @@ pub struct Args {
     )]
     pub timeout: u64,
 
-    // Tokenization
     #[arg(
         long,
         help = "Hugging Face tokenizer (defaults to model name)",
@@ -142,7 +137,6 @@ pub struct Args {
     )]
     pub use_server_token_count: bool,
 
-    // Output
     #[arg(
         long,
         value_enum,
@@ -199,24 +193,21 @@ impl Args {
     }
 
     pub fn validate(&self) -> Result<(), String> {
-        if matches!(self.api, ApiType::Messages) && self.mean_output_tokens.is_none() {
-            return Err("--mean-output-tokens is required for --api messages".to_string());
+        if matches!(self.api, ApiType::Messages) && self.output_cap.is_none() {
+            return Err("--output-cap is required for --api messages".to_string());
         }
-        if let Some(thinking_budget) = self.thinking_budget_tokens {
+        if let Some(thinking_budget) = self.thinking_budget {
             if !matches!(self.api, ApiType::Messages) {
-                return Err("--thinking-budget-tokens requires --api messages".to_string());
+                return Err("--thinking-budget requires --api messages".to_string());
             }
             if thinking_budget < 1024 {
-                return Err("--thinking-budget-tokens must be at least 1024".to_string());
+                return Err("--thinking-budget must be at least 1024".to_string());
             }
-            let mean_output_tokens = self
-                .mean_output_tokens
-                .expect("--mean-output-tokens is required for --api messages");
-            if mean_output_tokens <= thinking_budget {
-                return Err(
-                    "--mean-output-tokens must be greater than --thinking-budget-tokens"
-                        .to_string(),
-                );
+            let output_cap = self
+                .output_cap
+                .expect("--output-cap is required for --api messages");
+            if output_cap <= thinking_budget {
+                return Err("--output-cap must be greater than --thinking-budget".to_string());
             }
         }
         Ok(())
@@ -281,7 +272,7 @@ mod tests {
     }
 
     #[test]
-    fn test_messages_api_requires_mean_output_tokens() {
+    fn test_messages_api_requires_output_cap() {
         let args = Args::try_parse_from([
             "llmnop",
             "--api",
@@ -299,7 +290,7 @@ mod tests {
     }
 
     #[test]
-    fn test_messages_api_allows_mean_output_tokens() {
+    fn test_messages_api_allows_output_cap() {
         let args = Args::try_parse_from([
             "llmnop",
             "--api",
@@ -310,7 +301,7 @@ mod tests {
             "https://api.anthropic.com/v1",
             "--api-key",
             "test-key",
-            "--mean-output-tokens",
+            "--output-cap",
             "150",
         ])
         .expect("parse args");
@@ -330,9 +321,9 @@ mod tests {
             "http://localhost:8000/v1",
             "--api-key",
             "test-key",
-            "--mean-output-tokens",
+            "--output-cap",
             "1500",
-            "--thinking-budget-tokens",
+            "--thinking-budget",
             "1024",
         ])
         .expect("parse args");
@@ -352,9 +343,9 @@ mod tests {
             "https://api.anthropic.com/v1",
             "--api-key",
             "test-key",
-            "--mean-output-tokens",
+            "--output-cap",
             "1500",
-            "--thinking-budget-tokens",
+            "--thinking-budget",
             "1023",
         ])
         .expect("parse args");
@@ -363,7 +354,7 @@ mod tests {
     }
 
     #[test]
-    fn test_thinking_budget_requires_larger_mean_output_tokens() {
+    fn test_thinking_budget_requires_larger_output_cap() {
         let args = Args::try_parse_from([
             "llmnop",
             "--api",
@@ -374,9 +365,9 @@ mod tests {
             "https://api.anthropic.com/v1",
             "--api-key",
             "test-key",
-            "--mean-output-tokens",
+            "--output-cap",
             "1024",
-            "--thinking-budget-tokens",
+            "--thinking-budget",
             "1024",
         ])
         .expect("parse args");
@@ -396,9 +387,9 @@ mod tests {
             "https://api.anthropic.com/v1",
             "--api-key",
             "test-key",
-            "--mean-output-tokens",
+            "--output-cap",
             "1500",
-            "--thinking-budget-tokens",
+            "--thinking-budget",
             "1024",
         ])
         .expect("parse args");

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -47,7 +47,7 @@ pub struct BenchmarkRequest {
     pub prompt: String,
     pub max_tokens: Option<u32>,
     pub thinking_budget_tokens: Option<u32>,
-    pub tokenizer: String,
+    pub tokenizer: std::sync::Arc<tokenizers::Tokenizer>,
     pub use_server_token_count: bool,
 }
 
@@ -415,14 +415,14 @@ fn compute_token_counts(
     prompt: &str,
     generated_text: &str,
     reasoning_text: &str,
-    tokenizer: &str,
+    tokenizer: &tokenizers::Tokenizer,
 ) -> Result<TokenCounts> {
-    let input_tokens = tokens::count_tokens(prompt, tokenizer)?;
-    let output_tokens = tokens::count_tokens(generated_text, tokenizer)?;
+    let input_tokens = u32::try_from(tokens::count(tokenizer, prompt)?)?;
+    let output_tokens = u32::try_from(tokens::count(tokenizer, generated_text)?)?;
     let reasoning_tokens = if reasoning_text.is_empty() {
         0
     } else {
-        tokens::count_tokens(reasoning_text, tokenizer)?
+        u32::try_from(tokens::count(tokenizer, reasoning_text)?)?
     };
 
     Ok(TokenCounts {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,7 @@ use client::ApiClient;
 use client::anthropic::messages::MessagesClient;
 use futures::{StreamExt, stream::FuturesUnordered};
 use indicatif::{ProgressBar, ProgressStyle};
-use prompt::{PromptConfig, generate_prompt};
-use rand::prelude::*;
-use rand_distr::Normal;
+use prompt::PromptGenerator;
 use std::io::{self, IsTerminal};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -36,26 +34,6 @@ fn unix_time_now_ns() -> u64 {
         .ok()
         .and_then(|d| u64::try_from(d.as_nanos()).ok())
         .unwrap_or_default()
-}
-
-fn sample_max_tokens(mean: u32, stddev: u32, min_exclusive: Option<u32>) -> u32 {
-    if stddev == 0 {
-        return mean.max(1);
-    }
-
-    let dist = Normal::new(mean as f64, stddev as f64).unwrap();
-    let mut rng = rand::rng();
-
-    loop {
-        let sample = dist.sample(&mut rng);
-        if sample < 1.0 {
-            continue;
-        }
-        let tokens = sample.ceil() as u32;
-        if min_exclusive.is_none_or(|min| tokens > min) {
-            return tokens;
-        }
-    }
 }
 
 async fn run_benchmark_task(
@@ -102,15 +80,25 @@ async fn main() -> Result<()> {
     let overall_start = Instant::now();
     let overall_start_unix_ns = unix_time_now_ns();
 
-    let prompt_config = PromptConfig {
-        mean_input_tokens: args.mean_input_tokens,
-        stddev_input_tokens: args.stddev_input_tokens,
-    };
-
+    let loaded_tokenizer = Arc::new(tokens::load(&tokenizer)?);
+    let generator = PromptGenerator::new(&loaded_tokenizer)?;
     let mut prompts = Vec::with_capacity(args.max_num_completed_requests as usize);
+    let mut rng = rand::rng();
     for _ in 0..args.max_num_completed_requests {
-        let prompt = generate_prompt(&prompt_config, &tokenizer)?;
-        prompts.push(prompt);
+        let target =
+            prompt::sample_length(&mut rng, args.input_tokens, args.input_tokens_stddev, 1)?;
+        let cap = args
+            .output_cap
+            .map(|mean| {
+                prompt::sample_length(
+                    &mut rng,
+                    mean,
+                    args.output_cap_stddev,
+                    args.thinking_budget.map_or(1, |b| b + 1),
+                )
+            })
+            .transpose()?;
+        prompts.push((generator.generate(&mut rng, target)?, cap));
     }
 
     let mut all_results = Vec::with_capacity(args.max_num_completed_requests as usize);
@@ -147,25 +135,17 @@ async fn main() -> Result<()> {
     while next_request_index < args.max_num_completed_requests
         && in_flight.len() < args.num_concurrent_requests as usize
     {
-        let prompt = &prompts[next_request_index as usize];
+        let (prompt, max_tokens) = &prompts[next_request_index as usize];
         let model_name = model.clone();
         let prompt_clone = prompt.clone();
         let client_clone = client.clone();
-        let tokenizer_clone = tokenizer.clone();
-        let min_output_tokens = if matches!(api, ApiType::Messages) {
-            args.thinking_budget_tokens
-        } else {
-            None
-        };
-        let max_tokens = args
-            .mean_output_tokens
-            .map(|mean| sample_max_tokens(mean, args.stddev_output_tokens, min_output_tokens));
+        let tokenizer_clone = loaded_tokenizer.clone();
 
         let request = BenchmarkRequest {
             model: model_name,
             prompt: prompt_clone,
-            max_tokens,
-            thinking_budget_tokens: args.thinking_budget_tokens,
+            max_tokens: *max_tokens,
+            thinking_budget_tokens: args.thinking_budget,
             tokenizer: tokenizer_clone,
             use_server_token_count,
         };
@@ -202,25 +182,18 @@ async fn main() -> Result<()> {
                 pb.inc(1);
 
                 if !timeout_occurred && next_request_index < args.max_num_completed_requests {
-                    let prompt = &prompts[next_request_index as usize];
+                    let (prompt, max_tokens) = &prompts[next_request_index as usize];
                     let model_name = model.clone();
                     let prompt_clone = prompt.clone();
                     let client_clone = client.clone();
-                    let tokenizer_clone = tokenizer.clone();
-                    let min_output_tokens = if matches!(api, ApiType::Messages) {
-                        args.thinking_budget_tokens
-                    } else {
-                        None
-                    };
-                    let max_tokens = args.mean_output_tokens.map(|mean| {
-                        sample_max_tokens(mean, args.stddev_output_tokens, min_output_tokens)
-                    });
+                    let tokenizer_clone = loaded_tokenizer.clone();
+
 
                     let request = BenchmarkRequest {
                         model: model_name,
                         prompt: prompt_clone,
-                        max_tokens,
-                        thinking_budget_tokens: args.thinking_budget_tokens,
+                        max_tokens: *max_tokens,
+                        thinking_budget_tokens: args.thinking_budget,
                         tokenizer: tokenizer_clone,
                         use_server_token_count,
                     };
@@ -269,10 +242,10 @@ async fn main() -> Result<()> {
     let config = BenchmarkConfig {
         model: &model,
         tokenizer: &tokenizer,
-        mean_input_tokens: args.mean_input_tokens,
-        stddev_input_tokens: args.stddev_input_tokens,
-        mean_output_tokens: args.mean_output_tokens,
-        stddev_output_tokens: args.stddev_output_tokens,
+        mean_input_tokens: args.input_tokens,
+        stddev_input_tokens: args.input_tokens_stddev,
+        mean_output_tokens: args.output_cap,
+        stddev_output_tokens: args.output_cap_stddev,
         num_concurrent_requests: args.num_concurrent_requests,
     };
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -645,8 +645,8 @@ fn build_summary(
         .collect();
 
     BenchmarkSummary {
-        version: "2026-05-03".to_string(),
-        schema_version: "2.0".to_string(),
+        version: "2026-09-06-workload.1".to_string(),
+        schema_version: "2.1".to_string(),
         llmnop_version: env!("CARGO_PKG_VERSION").to_string(),
         benchmark_id: run_id.to_string(),
         benchmark_slug: benchmark_slug(config),
@@ -1038,8 +1038,8 @@ mod tests {
             1_700_000_001_000_000_000,
         );
 
-        assert_eq!(summary.schema_version, "2.0");
-        assert_eq!(summary.version, "2026-05-03");
+        assert_eq!(summary.schema_version, "2.1");
+        assert_eq!(summary.version, "2026-09-06-workload.1");
         assert_eq!(summary.request_latency.unit, "ms");
         assert_eq!(
             summary.output_token_throughput_per_request.unit,

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,151 +1,188 @@
-use crate::tokens;
-use anyhow::Result;
-use rand::prelude::*;
-use rand_distr::Normal;
-use std::collections::HashMap;
-use std::sync::{Arc, LazyLock, Mutex};
+use anyhow::{Result, anyhow, bail};
+use rand::RngExt;
+use rand_distr::{Distribution, Normal};
+use tokenizers::Tokenizer;
 
-static SHAKESPEARE: &str = include_str!("assets/shakespeare.txt");
-// Fixed-size char chunks keep deterministic boundaries while enabling parallel tokenization.
-const MAX_CHARS_PER_CHUNK: usize = 10_000;
-
-static TOKENIZED_CORPUS_CACHE: LazyLock<Mutex<HashMap<String, Arc<Vec<u32>>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-pub struct PromptConfig {
-    pub mean_input_tokens: u32,
-    pub stddev_input_tokens: u32,
-}
-
-fn build_corpus_chunks() -> Vec<String> {
-    let mut chunks = Vec::new();
-    let mut current_chunk = String::new();
-    let mut char_count = 0usize;
-
-    for line in SHAKESPEARE
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-    {
-        if !current_chunk.is_empty() {
-            current_chunk.push(' ');
-        }
-        current_chunk.push_str(line);
-        char_count += line.chars().count();
-
-        if char_count >= MAX_CHARS_PER_CHUNK {
-            chunks.push(std::mem::take(&mut current_chunk));
-            char_count = 0;
-        }
-    }
-
-    if !current_chunk.is_empty() {
-        chunks.push(current_chunk);
-    }
-
-    chunks
-}
-
-fn get_tokenized_corpus(tokenizer: &str) -> Result<Arc<Vec<u32>>> {
-    let mut cache = TOKENIZED_CORPUS_CACHE.lock().unwrap();
-
-    if let Some(corpus) = cache.get(tokenizer) {
-        return Ok(Arc::clone(corpus));
-    }
-
-    let chunks = build_corpus_chunks();
-    let encoded_chunks = tokens::encode_batch(&chunks, tokenizer)?;
-    let total_tokens: usize = encoded_chunks.iter().map(|chunk| chunk.len()).sum();
-    let mut token_ids = Vec::with_capacity(total_tokens);
-    for chunk in encoded_chunks {
-        token_ids.extend(chunk);
-    }
-    let token_ids = Arc::new(token_ids);
-    cache.insert(tokenizer.to_string(), Arc::clone(&token_ids));
-
-    Ok(token_ids)
-}
-
-fn sample_tokens(corpus: &[u32], num_tokens: usize) -> Vec<u32> {
-    if corpus.is_empty() || num_tokens == 0 {
-        return Vec::new();
-    }
-
-    let corpus_size = corpus.len();
-    let num_tokens = num_tokens.min(corpus_size);
-    let start_idx = rand::rng().random_range(0..corpus_size);
-    let end_idx = start_idx + num_tokens;
-
-    if end_idx <= corpus_size {
-        corpus[start_idx..end_idx].to_vec()
-    } else {
-        let mut tokens = corpus[start_idx..].to_vec();
-        tokens.extend_from_slice(&corpus[..end_idx - corpus_size]);
-        tokens
-    }
-}
-
-fn sample_num_tokens(mean: u32, stddev: u32) -> u32 {
+pub const CORPUS: &str = include_str!("assets/shakespeare.txt");
+pub fn sample_length(
+    rng: &mut impl rand::Rng,
+    mean: u32,
+    stddev: u32,
+    minimum: u32,
+) -> Result<u32> {
     if stddev == 0 {
-        return mean.max(1);
+        return Ok(mean.max(minimum));
     }
-
-    let dist = Normal::new(mean as f64, stddev as f64).unwrap();
-    let mut rng = rand::rng();
-
-    loop {
-        let sample = dist.sample(&mut rng);
-        if sample >= 1.0 {
-            return sample.ceil() as u32;
+    let normal = Normal::new(f64::from(mean), f64::from(stddev))?;
+    for _ in 0..10_000 {
+        let sample = normal.sample(rng);
+        if sample >= 0.0 && sample.ceil() <= f64::from(u32::MAX) {
+            let n = (sample.ceil() as u32).max(1);
+            if n >= minimum {
+                return Ok(n);
+            }
         }
     }
+    bail!("could not sample a length within the requested bounds")
 }
 
-pub fn generate_prompt(config: &PromptConfig, tokenizer: &str) -> Result<String> {
-    let corpus = get_tokenized_corpus(tokenizer)?;
+pub struct PromptGenerator<'a> {
+    tokenizer: &'a Tokenizer,
+    corpus: Vec<u32>,
+}
 
-    let num_tokens = sample_num_tokens(config.mean_input_tokens, config.stddev_input_tokens);
-    let token_ids = sample_tokens(&corpus, num_tokens as usize);
+impl<'a> PromptGenerator<'a> {
+    pub fn new(tokenizer: &'a Tokenizer) -> Result<Self> {
+        let mut chunks = Vec::new();
+        let mut text = String::new();
+        let mut chars = 0;
+        for line in CORPUS.lines().map(str::trim).filter(|s| !s.is_empty()) {
+            if !text.is_empty() {
+                text.push(' ');
+            }
+            text.push_str(line);
+            chars += line.chars().count();
+            if chars >= 10_000 {
+                chunks.push(std::mem::take(&mut text));
+                chars = 0;
+            }
+        }
+        if !text.is_empty() {
+            chunks.push(text);
+        }
+        let corpus = tokenizer
+            .encode_batch(chunks, false)
+            .map_err(|e| anyhow!("corpus tokenization failed: {e}"))?
+            .into_iter()
+            .flat_map(|e| e.get_ids().to_vec())
+            .collect::<Vec<_>>();
+        if corpus.is_empty() {
+            bail!("tokenizer produced an empty corpus");
+        }
+        Ok(Self { tokenizer, corpus })
+    }
 
-    tokens::decode(&token_ids, tokenizer)
+    fn sample(&self, rng: &mut impl rand::Rng, n: usize) -> Vec<u32> {
+        let start = rng.random_range(0..self.corpus.len());
+        self.corpus
+            .iter()
+            .cycle()
+            .skip(start)
+            .take(n)
+            .copied()
+            .collect()
+    }
+
+    pub fn generate(&self, rng: &mut impl rand::Rng, target: u32) -> Result<String> {
+        let target = target as usize;
+        let mut tokens = self.sample(rng, target);
+        for adjustment in 0..=10 {
+            let text = self
+                .tokenizer
+                .decode(&tokens, false)
+                .map_err(|e| anyhow!("prompt decode failed: {e}"))?;
+            tokens = self
+                .tokenizer
+                .encode(text.as_str(), false)
+                .map_err(|e| anyhow!("prompt tokenization failed: {e}"))?
+                .get_ids()
+                .to_vec();
+            match tokens.len().cmp(&target) {
+                std::cmp::Ordering::Equal => return Ok(text),
+                _ if adjustment == 10 => break,
+                std::cmp::Ordering::Greater => tokens.truncate(target),
+                std::cmp::Ordering::Less => tokens.extend(self.sample(rng, target - tokens.len())),
+            }
+        }
+        bail!("could not generate a prompt with {target} tokens after 10 adjustments")
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tokens;
+    use rand::{SeedableRng, rngs::StdRng};
 
     #[test]
-    fn sample_tokens_returns_requested_count_when_within_corpus() {
-        let corpus: Vec<u32> = (0..100).collect();
-        let result = sample_tokens(&corpus, 50);
-        assert_eq!(result.len(), 50);
+    fn corpus_sampling_wraps_more_than_once() {
+        let tokenizer = tokens::test_tokenizer();
+        let generator = PromptGenerator {
+            tokenizer: &tokenizer,
+            corpus: vec![1, 2, 3],
+        };
+        let mut rng = StdRng::seed_from_u64(42);
+        let sampled = generator.sample(&mut rng, 10);
+        assert_eq!(sampled.len(), 10);
+        for pair in sampled.windows(2) {
+            assert_eq!(pair[1], pair[0] % 3 + 1);
+        }
     }
 
     #[test]
-    fn sample_tokens_caps_at_corpus_size_when_exceeding() {
-        let corpus: Vec<u32> = (0..100).collect();
-        let result = sample_tokens(&corpus, 500);
-        assert_eq!(result.len(), 100);
+    fn prompts_reencode_to_target() {
+        let tokenizer = tokens::test_tokenizer();
+        let generator = PromptGenerator {
+            tokenizer: &tokenizer,
+            corpus: vec![1, 2, 3, 4],
+        };
+        for n in [1, 8, 25] {
+            let a = generator
+                .generate(&mut StdRng::seed_from_u64(42), n)
+                .unwrap();
+            assert_eq!(tokens::count(&tokenizer, &a).unwrap(), u64::from(n));
+        }
     }
 
     #[test]
-    fn sample_tokens_handles_exact_corpus_size() {
-        let corpus: Vec<u32> = (0..100).collect();
-        let result = sample_tokens(&corpus, 100);
-        assert_eq!(result.len(), 100);
+    fn verifies_the_last_repair_and_rejects_exhausted_repairs() {
+        use tokenizers::decoders::sequence::Sequence;
+        use tokenizers::normalizers::replace::{Replace, ReplacePattern};
+        for &last in b"kl" {
+            let vocab = (b'a'..=last)
+                .enumerate()
+                .map(|(i, c)| ((c as char).to_string(), i as u32))
+                .collect();
+            let model = tokenizers::models::wordlevel::WordLevel::builder()
+                .vocab(vocab)
+                .unk_token("a".into())
+                .build()
+                .unwrap();
+            let mut tokenizer = Tokenizer::new(model);
+            tokenizer.with_pre_tokenizer(Some(
+                tokenizers::pre_tokenizers::whitespace::WhitespaceSplit,
+            ));
+            let decoders = (b'a'..last)
+                .rev()
+                .map(|c| {
+                    let next = (c + 1) as char;
+                    Replace::new(
+                        ReplacePattern::Regex(format!("^{}$", c as char)),
+                        format!("{next} {next}"),
+                    )
+                    .unwrap()
+                    .into()
+                })
+                .collect();
+            tokenizer.with_decoder(Some(Sequence::new(decoders)));
+            let generator = PromptGenerator {
+                tokenizer: &tokenizer,
+                corpus: vec![0],
+            };
+            let result = generator.generate(&mut StdRng::seed_from_u64(42), 1);
+            if last == b'k' {
+                assert_eq!(result.unwrap(), "k");
+            } else {
+                assert!(result.is_err());
+            }
+        }
     }
 
     #[test]
-    fn sample_tokens_returns_empty_for_empty_corpus() {
-        let corpus: Vec<u32> = vec![];
-        let result = sample_tokens(&corpus, 50);
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn sample_tokens_returns_empty_for_zero_tokens() {
-        let corpus: Vec<u32> = (0..100).collect();
-        let result = sample_tokens(&corpus, 0);
-        assert!(result.is_empty());
+    fn caps_stay_above_thinking_budget() {
+        let mut rng = StdRng::seed_from_u64(2);
+        for _ in 0..1000 {
+            assert!(sample_length(&mut rng, 1100, 300, 1025).unwrap() > 1024);
+        }
     }
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,51 +1,80 @@
 use anyhow::{Result, anyhow};
-use std::collections::HashMap;
-use std::sync::{Arc, LazyLock, Mutex};
+use std::path::Path;
 use tokenizers::Tokenizer;
 
-static TOKENIZER_CACHE: LazyLock<Mutex<HashMap<String, Arc<Tokenizer>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-fn get_tokenizer(model_name: &str) -> Result<Arc<Tokenizer>> {
-    let mut cache = TOKENIZER_CACHE.lock().unwrap();
-
-    if let Some(tokenizer) = cache.get(model_name) {
-        return Ok(tokenizer.clone());
+pub fn load(name: &str) -> Result<Tokenizer> {
+    let mut tokenizer = if Path::new(name).is_file() {
+        Tokenizer::from_file(name)
+    } else {
+        Tokenizer::from_pretrained(name, None)
     }
-
-    let tokenizer = Tokenizer::from_pretrained(model_name, None)
-        .map_err(|e| anyhow!("Failed to load tokenizer for '{}': {}", model_name, e))?;
-
-    let tokenizer_arc = Arc::new(tokenizer);
-    cache.insert(model_name.to_string(), tokenizer_arc.clone());
-
-    Ok(tokenizer_arc)
+    .map_err(|e| anyhow!("failed to load tokenizer {name}: {e}"))?;
+    tokenizer
+        .with_truncation(None)
+        .map_err(|e| anyhow!("{e}"))?;
+    tokenizer.with_padding(None);
+    Ok(tokenizer)
 }
 
-pub fn count_tokens(text: &str, model_name: &str) -> Result<u32> {
-    let tokenizer = get_tokenizer(model_name)?;
-    let encoding = tokenizer
+pub fn count(tokenizer: &Tokenizer, text: &str) -> Result<u64> {
+    Ok(tokenizer
         .encode(text, false)
-        .map_err(|e| anyhow!("Tokenization error for model '{}': {}", model_name, e))?;
-    Ok(encoding.get_ids().len() as u32)
+        .map_err(|e| anyhow!("tokenization failed: {e}"))?
+        .len() as u64)
 }
 
-pub fn encode_batch(texts: &[String], model_name: &str) -> Result<Vec<Vec<u32>>> {
-    let tokenizer = get_tokenizer(model_name)?;
-    let inputs: Vec<&str> = texts.iter().map(|text| text.as_str()).collect();
-    let encodings = tokenizer
-        .encode_batch(inputs, false)
-        .map_err(|e| anyhow!("Tokenization error for model '{}': {}", model_name, e))?;
-    Ok(encodings
-        .into_iter()
-        .map(|encoding| encoding.get_ids().to_vec())
-        .collect())
+#[cfg(test)]
+pub fn test_tokenizer() -> Tokenizer {
+    let vocab = [
+        ("[UNK]".into(), 0),
+        ("a".into(), 1),
+        ("b".into(), 2),
+        ("c".into(), 3),
+        ("d".into(), 4),
+    ]
+    .into_iter()
+    .collect();
+    let model = tokenizers::models::wordlevel::WordLevel::builder()
+        .vocab(vocab)
+        .unk_token("[UNK]".into())
+        .build()
+        .unwrap();
+    let mut tokenizer = Tokenizer::new(model);
+    tokenizer.with_pre_tokenizer(Some(
+        tokenizers::pre_tokenizers::whitespace::WhitespaceSplit,
+    ));
+    tokenizer
 }
 
-pub fn decode(token_ids: &[u32], model_name: &str) -> Result<String> {
-    let tokenizer = get_tokenizer(model_name)?;
-    let text = tokenizer
-        .decode(token_ids, true)
-        .map_err(|e| anyhow!("Decoding error for model '{}': {}", model_name, e))?;
-    Ok(text)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_tokenizer_loading_disables_padding_and_truncation() {
+        let mut tokenizer = test_tokenizer();
+        tokenizer
+            .with_truncation(Some(tokenizers::TruncationParams {
+                max_length: 1,
+                ..Default::default()
+            }))
+            .unwrap();
+        tokenizer.with_padding(Some(tokenizers::PaddingParams {
+            strategy: tokenizers::PaddingStrategy::Fixed(4),
+            ..Default::default()
+        }));
+        let path = std::env::temp_dir().join(format!(
+            "llmnop-tokenizer-{}.json",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        tokenizer.save(&path, false).unwrap();
+        let loaded = load(path.to_str().unwrap()).unwrap();
+        assert_eq!(count(&loaded, "a b c").unwrap(), 3);
+        assert!(loaded.get_padding().is_none());
+        assert!(loaded.get_truncation().is_none());
+        std::fs::remove_file(path).unwrap();
+    }
 }


### PR DESCRIPTION
## Summary

Generate randomly sampled Shakespeare prompts using AIPerf's sonnet mechanics, with exact locally verified token lengths.

## Changes

- Normalize and tokenize the corpus before sampling contiguous windows, wrapping as needed.
- Re-encode decoded prompts and repair length differences; fail when the requested length cannot be achieved.
- Separate input-token targets from requested output caps, with optional variation in each.
- Support local tokenizer files and disable tokenizer padding and truncation.
