### PR TITLE
feat(benchmark): define request budgets and run lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+
+- Add `--warmup` for requests completed before measurement and excluded from benchmark statistics. ([#71](https://github.com/jpreagan/llmnop/pull/71))
+
+### Changed
+
+- Replace `--max-num-completed-requests` and `--num-concurrent-requests` with `--requests` and `--concurrency`. Failed attempts count toward the request budget and are not retried. ([#71](https://github.com/jpreagan/llmnop/pull/71))
+- Replace the benchmark-wide `--timeout` with a per-request `--request-timeout`. Save partial results on timeout or interruption. ([#71](https://github.com/jpreagan/llmnop/pull/71))
+
 ## [0.10.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ When `--thinking-budget` is set, it must be at least 1024 and smaller than `--ou
 
 | Flag                           | Default | Description                |
 | ------------------------------ | ------- | -------------------------- |
-| `--max-num-completed-requests` | 10      | Total requests to complete |
-| `--num-concurrent-requests`    | 1       | Parallel request count     |
-| `--timeout`                    | 600     | Request timeout in seconds |
+| `--requests` | 10      | Total requests to complete |
+| `--concurrency`    | 1       | Parallel request count     |
+| `--request-timeout`                    | 600     | Request timeout in seconds |
 
 ### Tokenization
 
@@ -135,8 +135,8 @@ Primary token metrics preserve llmnop's measured semantics: `output_token_count`
 ```bash
 llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
   --model Qwen/Qwen3-4B-Instruct-2507 \
-  --num-concurrent-requests 10 \
-  --max-num-completed-requests 100
+  --concurrency 10 \
+  --requests 100
 ```
 
 **Controlled benchmark with fixed output length:**
@@ -168,7 +168,7 @@ llmnop --api messages --url http://localhost:8000/v1 --api-key token-abc123 \
 llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
   --model Qwen/Qwen3-4B-Instruct-2507 \
   --output-format json \
-  --max-num-completed-requests 1 | jq '.request_latency.p99'
+  --requests 1 | jq '.request_latency.p99'
 ```
 
 **Custom tokenizer when model name doesn't match Hugging Face:**
@@ -221,3 +221,8 @@ Streaming clients require an explicit completion event; malformed and truncated 
 TTFT includes exposed reasoning; TTFO requires visible text. Missing timings are absent,
 and generation metrics exclude both the initial wait and completion metadata after the final text event.
 Token counts use assembled text, with provider usage kept separate. HTTP retries and redirects are disabled.
+
+Each measured attempt counts toward `--requests`, including failures; requests are not retried.
+`--concurrency` bounds active requests. `--warmup` is a separate phase excluded from measured results.
+`--request-timeout` limits each request through stream completion. Ctrl-C stops new work and records partial attempts.
+Per-attempt records are flushed to `requests.jsonl`, including statuses, deadlines, and partial observations.

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,11 +1,12 @@
-#[cfg(feature = "self-update")]
-use clap::Subcommand;
 use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
 use clap::error::ErrorKind;
-use clap::{CommandFactory, Parser, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use serde::Serialize;
+use std::time::Duration;
 
-#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, ValueEnum, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum ApiType {
     Chat,
     Responses,
@@ -19,9 +20,9 @@ pub enum OutputFormat {
     None,
 }
 
-#[cfg(feature = "self-update")]
 #[derive(Debug, Subcommand)]
 pub enum Command {
+    #[command(about = "Update llmnop (standalone installs only)")]
     Update,
 }
 
@@ -31,27 +32,26 @@ const STYLES: Styles = Styles::styled()
     .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
     .placeholder(AnsiColor::Cyan.on_default());
 
-#[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None, styles = STYLES)]
-#[cfg_attr(feature = "self-update", command(subcommand_negates_reqs = true))]
+#[derive(Parser, Debug, Serialize)]
+#[command(version, about, long_about = None, styles = STYLES, subcommand_negates_reqs = true)]
 pub struct Args {
-    #[cfg(feature = "self-update")]
     #[command(subcommand)]
+    #[serde(skip)]
     pub command: Option<Command>,
-
     #[arg(
         long,
-        help = "Base URL (e.g., http://localhost:8000/v1)",
+        value_name = "URL",
+        help = "API base URL, including its version prefix",
         help_heading = "Endpoint"
     )]
     pub url: Option<String>,
-
-    #[arg(long, help = "API key", help_heading = "Endpoint")]
-    pub api_key: Option<String>,
-
-    #[arg(short, long, help = "Model name", help_heading = "Endpoint")]
+    #[arg(
+        short,
+        long,
+        help = "Model identifier sent to the endpoint",
+        help_heading = "Endpoint"
+    )]
     pub model: Option<String>,
-
     #[arg(
         long,
         value_enum,
@@ -60,128 +60,80 @@ pub struct Args {
         help_heading = "Endpoint"
     )]
     pub api: ApiType,
-
     #[arg(
         long,
-        default_value = "550",
-        help = "Target input length",
-        help_heading = "Request Shaping"
+        value_name = "KEY",
+        help = "Authentication credential",
+        help_heading = "Endpoint"
     )]
-    pub input_tokens: u32,
-
+    #[serde(skip)]
+    pub api_key: Option<String>,
     #[arg(
         long,
-        default_value = "0",
-        help = "Input length variance",
-        help_heading = "Request Shaping"
-    )]
-    pub input_tokens_stddev: u32,
-
-    #[arg(
-        long,
-        help = "Mean output token cap to request [default: none]",
-        help_heading = "Request Shaping"
-    )]
-    pub output_cap: Option<u32>,
-
-    #[arg(
-        long,
-        default_value = "0",
-        help = "Output length variance",
-        help_heading = "Request Shaping"
-    )]
-    pub output_cap_stddev: u32,
-
-    #[arg(
-        long,
-        help = "Enable Anthropic Messages thinking with this token budget",
-        help_heading = "Request Shaping"
-    )]
-    pub thinking_budget: Option<u32>,
-
-    #[arg(
-        long,
-        default_value = "10",
-        help = "Number of requests",
-        help_heading = "Load Testing"
-    )]
-    pub max_num_completed_requests: u32,
-
-    #[arg(
-        long,
-        default_value = "1",
-        help = "Parallel requests",
-        help_heading = "Load Testing"
-    )]
-    pub num_concurrent_requests: u32,
-
-    #[arg(
-        long,
-        default_value = "600",
-        help = "Request timeout",
-        help_heading = "Load Testing"
-    )]
-    pub timeout: u64,
-
-    #[arg(
-        long,
-        help = "Hugging Face tokenizer (defaults to model name)",
-        help_heading = "Tokenization"
+        help = "Tokenizer for prompt sizing and local counts [default: model identifier]",
+        help_heading = "Endpoint"
     )]
     pub tokenizer: Option<String>,
-
+    #[arg(long, value_name = "N", default_value_t = 550, value_parser = clap::value_parser!(u32).range(1..), help = "Mean prompt-text token target", help_heading = "Workload")]
+    pub input_tokens: u32,
     #[arg(
         long,
-        help = "Request provider-reported token usage and record it separately",
-        help_heading = "Tokenization"
+        value_name = "N",
+        default_value_t = 0,
+        help = "Prompt-target standard deviation",
+        help_heading = "Workload"
+    )]
+    pub input_tokens_stddev: u32,
+    #[arg(long, value_name = "N", value_parser = clap::value_parser!(u32).range(1..), help = "Mean requested generation-token cap [default: omitted; required for messages]", help_heading = "Workload")]
+    pub output_cap: Option<u32>,
+    #[arg(
+        long,
+        value_name = "N",
+        default_value_t = 0,
+        help = "Generation-cap standard deviation",
+        help_heading = "Workload"
+    )]
+    pub output_cap_stddev: u32,
+    #[arg(long, value_name = "N", value_parser = clap::value_parser!(u32).range(1024..), help = "Messages API thinking-token budget", help_heading = "Workload")]
+    pub thinking_budget: Option<u32>,
+    #[arg(short = 'n', long, value_name = "N", default_value_t = 10, value_parser = clap::value_parser!(u32).range(1..), help = "Measured request attempts", help_heading = "Run")]
+    pub requests: u32,
+    #[arg(short = 'c', long, value_name = "N", default_value_t = 1, value_parser = clap::value_parser!(u32).range(1..), help = "Maximum simultaneous requests", help_heading = "Run")]
+    pub concurrency: u32,
+    #[arg(
+        long,
+        value_name = "N",
+        default_value_t = 0,
+        help = "Total warmup attempts",
+        help_heading = "Run"
+    )]
+    pub warmup: u32,
+    #[arg(
+        long,
+        value_name = "SECONDS",
+        default_value_t = 600.0,
+        help = "Deadline for each complete request",
+        help_heading = "Run"
+    )]
+    pub request_timeout: f64,
+    #[arg(long, value_enum, default_value = "table", help_heading = "Output")]
+    #[serde(skip)]
+    pub output_format: OutputFormat,
+    #[arg(long, help = "Emit summary JSON", help_heading = "Output")]
+    #[serde(skip)]
+    pub json: bool,
+    #[arg(short = 'q', long, help = "Suppress stdout", help_heading = "Output")]
+    #[serde(skip)]
+    pub quiet: bool,
+    #[arg(
+        long,
+        help = "Request provider-reported usage",
+        help_heading = "Output"
     )]
     pub use_server_token_count: bool,
-
-    #[arg(
-        long,
-        value_enum,
-        default_value = "table",
-        help = "Stdout output format",
-        help_heading = "Output"
-    )]
-    pub output_format: OutputFormat,
-
-    #[arg(
-        long,
-        help = "Emit benchmark summary JSON to stdout (alias for --output-format json)",
-        help_heading = "Output"
-    )]
-    pub json: bool,
-
-    #[arg(
-        short = 'q',
-        long,
-        help = "Suppress stdout output (alias for --output-format none)",
-        help_heading = "Output"
-    )]
-    pub quiet: bool,
 }
 
 impl Args {
-    pub fn require_benchmark_args(&self) -> Result<(&str, &str), clap::Error> {
-        let url = self
-            .url
-            .as_deref()
-            .ok_or_else(|| Self::missing_required_arg("--url"))?;
-        let model = self
-            .model
-            .as_deref()
-            .ok_or_else(|| Self::missing_required_arg("--model"))?;
-        Ok((url, model))
-    }
-
-    fn missing_required_arg(arg: &str) -> clap::Error {
-        Self::command().error(
-            ErrorKind::MissingRequiredArgument,
-            format!("the following required argument was not provided: {arg}"),
-        )
-    }
-
     pub fn effective_output_format(&self) -> OutputFormat {
         if self.quiet {
             OutputFormat::None
@@ -192,23 +144,60 @@ impl Args {
         }
     }
 
-    pub fn validate(&self) -> Result<(), String> {
-        if matches!(self.api, ApiType::Messages) && self.output_cap.is_none() {
-            return Err("--output-cap is required for --api messages".to_string());
+    pub fn validate(&self) -> Result<(), clap::Error> {
+        let invalid = |message: &str| Self::command().error(ErrorKind::ValueValidation, message);
+        for (name, value) in [("--url", &self.url), ("--model", &self.model)] {
+            if value.as_ref().is_none_or(|s| s.trim().is_empty()) {
+                return Err(Self::command().error(
+                    ErrorKind::MissingRequiredArgument,
+                    format!("{name} is required for benchmarks"),
+                ));
+            }
         }
-        if let Some(thinking_budget) = self.thinking_budget {
-            if !matches!(self.api, ApiType::Messages) {
-                return Err("--thinking-budget requires --api messages".to_string());
+        let url = reqwest::Url::parse(self.url.as_deref().unwrap())
+            .map_err(|_| invalid("--url must be an HTTP(S) base URL"))?;
+        if !matches!(url.scheme(), "http" | "https") || url.host_str().is_none() {
+            return Err(invalid("--url must be an HTTP(S) base URL"));
+        }
+        if !url.username().is_empty()
+            || url.password().is_some()
+            || url.query().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(invalid(
+                "--url must not contain credentials, a query, or a fragment",
+            ));
+        }
+        if self.api == ApiType::Messages && self.output_cap.is_none() {
+            return Err(invalid("--output-cap is required for --api messages"));
+        }
+        if self.output_cap_stddev > 0 && self.output_cap.is_none() {
+            return Err(invalid("--output-cap-stddev requires --output-cap"));
+        }
+        if let Some(budget) = self.thinking_budget {
+            if self.api != ApiType::Messages {
+                return Err(invalid("--thinking-budget requires --api messages"));
             }
-            if thinking_budget < 1024 {
-                return Err("--thinking-budget must be at least 1024".to_string());
+            if self.output_cap.is_none_or(|cap| cap <= budget) {
+                return Err(invalid("--output-cap must exceed --thinking-budget"));
             }
-            let output_cap = self
-                .output_cap
-                .expect("--output-cap is required for --api messages");
-            if output_cap <= thinking_budget {
-                return Err("--output-cap must be greater than --thinking-budget".to_string());
-            }
+        }
+        if Duration::try_from_secs_f64(self.request_timeout).is_err() || self.request_timeout <= 0.0
+        {
+            return Err(invalid(
+                "--request-timeout must be a finite positive duration",
+            ));
+        }
+        if self.requests.checked_add(self.warmup).is_none() {
+            return Err(invalid(
+                "--requests plus --warmup exceeds the supported request count",
+            ));
+        }
+        if std::time::Instant::now()
+            .checked_add(Duration::from_secs_f64(self.request_timeout))
+            .is_none()
+        {
+            return Err(invalid("--request-timeout exceeds the supported duration"));
         }
         Ok(())
     }
@@ -217,342 +206,46 @@ impl Args {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::Parser;
 
     #[test]
-    fn test_default_api_type_is_chat() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--model",
-            "test-model",
-            "--url",
-            "http://localhost:8000/v1",
-            "--api-key",
-            "test-key",
-        ])
-        .expect("parse args");
-
-        assert!(matches!(args.api, ApiType::Chat));
+    fn rejects_invalid_workloads_before_connecting() {
+        for flags in [
+            vec!["--requests", "0"],
+            vec!["--concurrency", "0"],
+            vec!["--input-tokens", "0"],
+            vec!["--output-cap", "0"],
+            vec!["--api", "messages"],
+            vec!["--thinking-budget", "1024"],
+            vec!["--output-cap-stddev", "1"],
+            vec!["--request-timeout", "NaN"],
+            vec!["--request-timeout", "0"],
+            vec![
+                "--api",
+                "messages",
+                "--output-cap",
+                "1024",
+                "--thinking-budget",
+                "1024",
+            ],
+        ] {
+            let mut argv = vec!["llmnop", "--url", "http://localhost/v1", "--model", "test"];
+            argv.extend(flags);
+            assert!(Args::try_parse_from(argv).map_or(true, |args| args.validate().is_err()));
+        }
     }
 
     #[test]
-    fn test_parse_responses_api_type() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--api",
-            "responses",
-            "--model",
-            "test-model",
-            "--url",
-            "http://localhost:8000/v1",
-            "--api-key",
-            "test-key",
-        ])
-        .expect("parse args");
-
-        assert!(matches!(args.api, ApiType::Responses));
+    fn help_and_update_do_not_require_an_endpoint() {
+        let help = Args::try_parse_from(["llmnop", "--help"]).unwrap_err();
+        assert_eq!(help.kind(), ErrorKind::DisplayHelp);
+        assert!(help.to_string().contains("standalone installs only"));
+        assert!(!help.to_string().contains("env:"));
+        assert!(Args::try_parse_from(["llmnop", "update"]).is_ok());
     }
 
     #[test]
-    fn test_parse_messages_api_type() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--api",
-            "messages",
-            "--model",
-            "test-model",
-            "--url",
-            "https://api.anthropic.com/v1",
-            "--api-key",
-            "test-key",
-        ])
-        .expect("parse args");
-
-        assert!(matches!(args.api, ApiType::Messages));
-    }
-
-    #[test]
-    fn test_messages_api_requires_output_cap() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--api",
-            "messages",
-            "--model",
-            "test-model",
-            "--url",
-            "https://api.anthropic.com/v1",
-            "--api-key",
-            "test-key",
-        ])
-        .expect("parse args");
-
-        assert!(args.validate().is_err());
-    }
-
-    #[test]
-    fn test_messages_api_allows_output_cap() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--api",
-            "messages",
-            "--model",
-            "test-model",
-            "--url",
-            "https://api.anthropic.com/v1",
-            "--api-key",
-            "test-key",
-            "--output-cap",
-            "150",
-        ])
-        .expect("parse args");
-
-        assert!(args.validate().is_ok());
-    }
-
-    #[test]
-    fn test_thinking_budget_requires_messages_api() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--api",
-            "chat",
-            "--model",
-            "test-model",
-            "--url",
-            "http://localhost:8000/v1",
-            "--api-key",
-            "test-key",
-            "--output-cap",
-            "1500",
-            "--thinking-budget",
-            "1024",
-        ])
-        .expect("parse args");
-
-        assert!(args.validate().is_err());
-    }
-
-    #[test]
-    fn test_thinking_budget_requires_at_least_1024_tokens() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--api",
-            "messages",
-            "--model",
-            "test-model",
-            "--url",
-            "https://api.anthropic.com/v1",
-            "--api-key",
-            "test-key",
-            "--output-cap",
-            "1500",
-            "--thinking-budget",
-            "1023",
-        ])
-        .expect("parse args");
-
-        assert!(args.validate().is_err());
-    }
-
-    #[test]
-    fn test_thinking_budget_requires_larger_output_cap() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--api",
-            "messages",
-            "--model",
-            "test-model",
-            "--url",
-            "https://api.anthropic.com/v1",
-            "--api-key",
-            "test-key",
-            "--output-cap",
-            "1024",
-            "--thinking-budget",
-            "1024",
-        ])
-        .expect("parse args");
-
-        assert!(args.validate().is_err());
-    }
-
-    #[test]
-    fn test_thinking_budget_allows_messages_api() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--api",
-            "messages",
-            "--model",
-            "test-model",
-            "--url",
-            "https://api.anthropic.com/v1",
-            "--api-key",
-            "test-key",
-            "--output-cap",
-            "1500",
-            "--thinking-budget",
-            "1024",
-        ])
-        .expect("parse args");
-
-        assert!(args.validate().is_ok());
-    }
-
-    #[test]
-    fn test_missing_url_is_error() {
-        let args = Args::try_parse_from(["llmnop", "--model", "test-model", "--api-key", "key"])
-            .expect("parse args");
-        assert!(args.require_benchmark_args().is_err());
-    }
-
-    #[test]
-    fn test_missing_model_is_error() {
-        let args = Args::try_parse_from(["llmnop", "--url", "http://localhost:8000/v1"])
-            .expect("parse args");
-        assert!(args.require_benchmark_args().is_err());
-    }
-
-    #[test]
-    fn test_missing_api_key_is_allowed() {
-        let args = Args::try_parse_from(["llmnop", "--model", "test-model", "--url", "http://x"])
-            .expect("parse args");
-        assert!(args.api_key.is_none());
-    }
-
-    #[test]
-    fn test_default_quiet_is_false() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--model",
-            "test-model",
-            "--url",
-            "http://localhost:8000/v1",
-            "--api-key",
-            "test-key",
-        ])
-        .expect("parse args");
-
-        assert!(!args.quiet);
-        assert!(!args.json);
-        assert!(matches!(args.output_format, OutputFormat::Table));
-    }
-
-    #[test]
-    fn test_parse_quiet_flag() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--model",
-            "test-model",
-            "--url",
-            "http://localhost:8000/v1",
-            "--api-key",
-            "test-key",
-            "--quiet",
-        ])
-        .expect("parse args");
-
-        assert!(args.quiet);
-        assert!(matches!(args.effective_output_format(), OutputFormat::None));
-    }
-
-    #[test]
-    fn test_parse_quiet_short_flag() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--model",
-            "test-model",
-            "--url",
-            "http://localhost:8000/v1",
-            "--api-key",
-            "test-key",
-            "-q",
-        ])
-        .expect("parse args");
-
-        assert!(args.quiet);
-        assert!(matches!(args.effective_output_format(), OutputFormat::None));
-    }
-
-    #[test]
-    fn test_parse_output_format_json() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--model",
-            "test-model",
-            "--url",
-            "http://localhost:8000/v1",
-            "--api-key",
-            "test-key",
-            "--output-format",
-            "json",
-        ])
-        .expect("parse args");
-
-        assert!(matches!(args.output_format, OutputFormat::Json));
-        assert!(matches!(args.effective_output_format(), OutputFormat::Json));
-    }
-
-    #[test]
-    fn test_parse_json_flag() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--model",
-            "test-model",
-            "--url",
-            "http://localhost:8000/v1",
-            "--api-key",
-            "test-key",
-            "--json",
-        ])
-        .expect("parse args");
-
-        assert!(args.json);
-        assert!(matches!(args.effective_output_format(), OutputFormat::Json));
-    }
-
-    #[test]
-    fn test_quiet_overrides_output_format() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--model",
-            "test-model",
-            "--url",
-            "http://localhost:8000/v1",
-            "--api-key",
-            "test-key",
-            "--output-format",
-            "json",
-            "--quiet",
-        ])
-        .expect("parse args");
-
-        assert!(matches!(args.output_format, OutputFormat::Json));
-        assert!(matches!(args.effective_output_format(), OutputFormat::None));
-    }
-
-    #[test]
-    fn test_quiet_overrides_json_flag() {
-        let args = Args::try_parse_from([
-            "llmnop",
-            "--model",
-            "test-model",
-            "--url",
-            "http://localhost:8000/v1",
-            "--api-key",
-            "test-key",
-            "--json",
-            "--quiet",
-        ])
-        .expect("parse args");
-
-        assert!(args.json);
-        assert!(args.quiet);
-        assert!(matches!(args.effective_output_format(), OutputFormat::None));
-    }
-
-    #[cfg(feature = "self-update")]
-    #[test]
-    fn test_parse_update_command() {
-        let args = Args::try_parse_from(["llmnop", "update"]).expect("parse args");
-        assert!(matches!(args.command, Some(Command::Update)));
+    fn config_never_serializes_credentials() {
+        let args = Args::parse_from(["llmnop", "--api-key", "secret"]);
+        assert!(!serde_json::to_string(&args).unwrap().contains("secret"));
     }
 }

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -1,7 +1,6 @@
 use crate::args::ApiType;
 use crate::client::{self, Event, Failure};
 use crate::tokens;
-use anyhow::{Result, anyhow};
 use eventsource_stream::Eventsource;
 use futures::StreamExt;
 use reqwest::{Client, Request};
@@ -27,6 +26,7 @@ static CLOCK: LazyLock<(Instant, u64)> = LazyLock::new(|| (Instant::now(), unix_
 #[serde(rename_all = "snake_case")]
 pub enum Phase {
     Measurement,
+    Warmup,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -335,133 +335,6 @@ pub async fn capture(
         },
         observation,
     }
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct BenchmarkResult {
-    pub ttft: Option<Duration>,
-    pub ttfo: Option<Duration>,
-    pub total_latency: Duration,
-    pub throughput: Option<f64>,
-    pub input_tokens: u32,
-    pub output_tokens: u32,
-    pub reasoning_tokens: u32,
-    pub inter_token_latency_s: Option<f64>,
-    pub inter_event_latency_s: Option<f64>,
-    pub total_tokens: u32,
-    pub provider_usage: Option<ProviderUsage>,
-    pub request_start_unix_ns: u64,
-    pub request_end_unix_ns: u64,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct ProviderUsage {
-    pub input_tokens: Option<u32>,
-    pub output_tokens: Option<u32>,
-    pub total_tokens: Option<u32>,
-    pub reasoning_tokens: Option<u32>,
-}
-
-#[derive(Debug, Clone)]
-pub struct BenchmarkRequest {
-    pub model: String,
-    pub url: String,
-    pub api_key: Option<String>,
-    pub timeout: Duration,
-    pub prompt: String,
-    pub max_tokens: Option<u32>,
-    pub thinking_budget_tokens: Option<u32>,
-    pub tokenizer: std::sync::Arc<tokenizers::Tokenizer>,
-    pub use_server_token_count: bool,
-}
-
-impl BenchmarkResult {
-    pub fn from_record(record: &RequestRecord) -> Result<Self> {
-        if record.status != Status::Completed {
-            return Err(anyhow!(
-                "{}",
-                record
-                    .error
-                    .as_ref()
-                    .map(|e| e.message.as_str())
-                    .unwrap_or("request failed")
-            ));
-        }
-        let m = &record.metrics;
-        let provider_usage = record.provider_usage.as_ref().map(|u| {
-            let n = |a: &str, b: &str| {
-                u.pointer(a)
-                    .or_else(|| u.pointer(b))
-                    .and_then(Value::as_u64)
-                    .and_then(|n| u32::try_from(n).ok())
-            };
-            ProviderUsage {
-                input_tokens: n("/input_tokens", "/prompt_tokens"),
-                output_tokens: n("/output_tokens", "/completion_tokens"),
-                total_tokens: n("/total_tokens", "/total_tokens"),
-                reasoning_tokens: n(
-                    "/output_tokens_details/reasoning_tokens",
-                    "/completion_tokens_details/reasoning_tokens",
-                ),
-            }
-        });
-        let output_tokens = u32::try_from(m.content_tokens.unwrap())?;
-        let reasoning_tokens = u32::try_from(m.reasoning_tokens.unwrap())?;
-        let input_tokens = u32::try_from(m.input_tokens)?;
-        Ok(Self {
-            ttft: m.ttft_ms.map(|n| Duration::from_secs_f64(n / 1000.0)),
-            ttfo: m.ttfo_ms.map(|n| Duration::from_secs_f64(n / 1000.0)),
-            total_latency: record.end.duration_since(record.start),
-            throughput: m.generation_tokens_per_second,
-            input_tokens,
-            output_tokens,
-            reasoning_tokens,
-            inter_token_latency_s: m.mean_inter_token_latency_ms.map(|n| n / 1000.0),
-            inter_event_latency_s: m.mean_inter_event_latency_ms.map(|n| n / 1000.0),
-            total_tokens: input_tokens
-                .checked_add(output_tokens)
-                .and_then(|n| n.checked_add(reasoning_tokens))
-                .ok_or_else(|| anyhow!("token total overflow"))?,
-            provider_usage,
-            request_start_unix_ns: record.start_time_unix_ns,
-            request_end_unix_ns: record.end_time_unix_ns,
-        })
-    }
-}
-
-pub async fn run_benchmark(
-    client: &Client,
-    api: ApiType,
-    request: BenchmarkRequest,
-) -> Result<BenchmarkResult> {
-    let body = client::request_body(
-        api,
-        &request.model,
-        &request.prompt,
-        request.max_tokens,
-        request.thinking_budget_tokens,
-        request.use_server_token_count,
-    );
-    let input_tokens = tokens::count(&request.tokenizer, &request.prompt)?;
-    let prepared = PreparedRequest {
-        id: 0,
-        phase: Phase::Measurement,
-        input_target: input_tokens.try_into()?,
-        input_tokens,
-        output_cap: request.max_tokens,
-        request: client::build_request(
-            client,
-            api,
-            &request.url,
-            request.api_key.as_deref(),
-            &body,
-        )?,
-    };
-    let (_cancel_tx, cancel) = watch::channel(false);
-    let record = capture(client.clone(), api, prepared, request.timeout, cancel)
-        .await
-        .finish(&request.tokenizer);
-    BenchmarkResult::from_record(&record)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,72 +9,35 @@ mod self_update;
 mod tests;
 mod tokens;
 
-use anyhow::Result;
-#[cfg(feature = "self-update")]
-use args::Command;
-use args::{ApiType, Args, OutputFormat};
-
-use benchmark::{BenchmarkRequest, BenchmarkResult, run_benchmark};
+use anyhow::{Context, Result};
+use args::{Args, Command, OutputFormat};
+use benchmark::{Phase, PreparedRequest, RequestRecord};
 use clap::Parser;
-
-use futures::{StreamExt, stream::FuturesUnordered};
 use indicatif::{ProgressBar, ProgressStyle};
+use output::{BenchmarkSummary, ResultsWriter};
 use prompt::PromptGenerator;
-use std::io::{self, IsTerminal};
+use std::collections::VecDeque;
+use std::io::{self, IsTerminal, Write};
+use std::process::ExitCode;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
-use tokio::time;
+use std::time::Duration;
+use tokenizers::Tokenizer;
+use tokio::sync::watch;
+use tokio::task::JoinSet;
 
-use output::{BenchmarkConfig, print_summary_to_stdout, write_results_json};
-
-fn unix_time_now_ns() -> u64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .ok()
-        .and_then(|d| u64::try_from(d.as_nanos()).ok())
-        .unwrap_or_default()
-}
-
-async fn run_benchmark_task(
-    client: Arc<reqwest::Client>,
-    api_type: ApiType,
-    request: BenchmarkRequest,
-) -> Result<BenchmarkResult> {
-    run_benchmark(&client, api_type, request).await
-}
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    let args = Args::parse();
-
-    #[cfg(feature = "self-update")]
-    if let Some(Command::Update) = args.command {
-        return self_update::run_update().await;
-    }
-
-    let (url, model) = match args.require_benchmark_args() {
-        Ok(values) => values,
-        Err(err) => err.exit(),
-    };
-    let model = model.to_string();
-    args.validate().map_err(|err| anyhow::anyhow!("{err}"))?;
-
-    let api = args.api;
-    let client = Arc::new(client::http_client()?);
-
-    let tokenizer = args.tokenizer.clone().unwrap_or_else(|| model.clone());
-    let use_server_token_count = args.use_server_token_count;
-    let overall_start = Instant::now();
-    let overall_start_unix_ns = unix_time_now_ns();
-
-    let loaded_tokenizer = Arc::new(tokens::load(&tokenizer)?);
-    let generator = PromptGenerator::new(&loaded_tokenizer)?;
-    let mut prompts = Vec::with_capacity(args.max_num_completed_requests as usize);
+fn prepare(
+    args: &Args,
+    client: &reqwest::Client,
+    tokenizer: &Tokenizer,
+    generator: &PromptGenerator<'_>,
+    phase: Phase,
+) -> Result<VecDeque<PreparedRequest>> {
+    let warmup = phase == Phase::Warmup;
+    let count = if warmup { args.warmup } else { args.requests };
+    let mut prepared = VecDeque::with_capacity(count as usize);
     let mut rng = rand::rng();
-    for _ in 0..args.max_num_completed_requests {
-        let target =
+    for index in 0..count {
+        let input_target =
             prompt::sample_length(&mut rng, args.input_tokens, args.input_tokens_stddev, 1)?;
         let cap = args
             .output_cap
@@ -87,187 +50,147 @@ async fn main() -> Result<()> {
                 )
             })
             .transpose()?;
-        prompts.push((generator.generate(&mut rng, target)?, cap));
+        let prompt = generator.generate(&mut rng, input_target)?;
+        let input_tokens = tokens::count(tokenizer, &prompt)?;
+        let body = client::request_body(
+            args.api,
+            args.model.as_deref().unwrap(),
+            &prompt,
+            cap,
+            args.thinking_budget,
+            args.use_server_token_count,
+        );
+        prepared.push_back(PreparedRequest {
+            id: if warmup { index } else { args.warmup + index },
+            phase,
+            input_target,
+            input_tokens,
+            output_cap: cap,
+            request: client::build_request(
+                client,
+                args.api,
+                args.url.as_deref().unwrap(),
+                args.api_key.as_deref(),
+                &body,
+            )?,
+        });
     }
+    Ok(prepared)
+}
 
-    let mut all_results = Vec::with_capacity(args.max_num_completed_requests as usize);
-
-    let mut in_flight = FuturesUnordered::new();
-    let mut next_request_index = 0;
-
-    let output_format = args.effective_output_format();
-    let disable_progress =
-        matches!(output_format, OutputFormat::None) || !io::stderr().is_terminal();
-
-    let pb = if disable_progress {
+async fn run_phase(
+    args: &Args,
+    client: &reqwest::Client,
+    tokenizer: &Arc<Tokenizer>,
+    mut requests: VecDeque<PreparedRequest>,
+    cancel: &watch::Receiver<bool>,
+    writer: &mut ResultsWriter,
+) -> Result<Vec<RequestRecord>> {
+    let pb = if matches!(args.effective_output_format(), OutputFormat::None)
+        || !io::stderr().is_terminal()
+    {
         ProgressBar::hidden()
     } else {
-        let pb = ProgressBar::new(args.max_num_completed_requests as u64);
-        pb.set_style(
-            ProgressStyle::default_bar()
-                .template(
-                    "{spinner:.green} [{elapsed_precise}] {bar:40.cyan/blue} {pos}/{len} ({eta})",
-                )
-                .unwrap()
-                .progress_chars("##-"),
-        );
-        pb.tick();
-        pb
+        ProgressBar::new(requests.len() as u64)
     };
-
-    let timeout_duration = Duration::from_secs(args.timeout);
-    let timeout_future = time::sleep(timeout_duration);
-    let mut timeout_occurred = false;
-
-    tokio::pin!(timeout_future);
-
-    while next_request_index < args.max_num_completed_requests
-        && in_flight.len() < args.num_concurrent_requests as usize
-    {
-        let (prompt, max_tokens) = &prompts[next_request_index as usize];
-        let model_name = model.clone();
-        let prompt_clone = prompt.clone();
-        let client_clone = client.clone();
-        let tokenizer_clone = loaded_tokenizer.clone();
-
-        let request = BenchmarkRequest {
-            model: model_name,
-            url: url.to_owned(),
-            api_key: args.api_key.clone(),
-            timeout: timeout_duration,
-            prompt: prompt_clone,
-            max_tokens: *max_tokens,
-            thinking_budget_tokens: args.thinking_budget,
-            tokenizer: tokenizer_clone,
-            use_server_token_count,
-        };
-
-        in_flight.push(tokio::spawn(run_benchmark_task(client_clone, api, request)));
-        next_request_index += 1;
-    }
-
+    pb.set_style(ProgressStyle::with_template(
+        "{spinner} [{elapsed_precise}] {pos}/{len}",
+    )?);
+    let mut in_flight = JoinSet::new();
+    let mut processing = JoinSet::new();
+    let mut records = Vec::with_capacity(requests.len());
+    let timeout = Duration::from_secs_f64(args.request_timeout);
     loop {
-        tokio::select! {
-            _ = &mut timeout_future, if !timeout_occurred => {
-                eprintln!(
-                    "\nTimeout reached after {} seconds. Collecting completed results...",
-                    args.timeout
-                );
-                timeout_occurred = true;
-            }
-
-            Some(done) = in_flight.next(), if !in_flight.is_empty() => {
-                match done {
-                    Ok(Ok(benchmark_result)) => {
-                        all_results.push(Ok(benchmark_result));
-                    }
-                    Ok(Err(e)) => {
-                        eprintln!("Request failed: {:?}", e);
-                        all_results.push(Err(e.to_string()));
-                    }
-                    Err(tokio_err) => {
-                        eprintln!("Tokio Join Error: {:?}", tokio_err);
-                        all_results.push(Err(format!("Tokio Join Error: {:?}", tokio_err)));
-                    }
-                }
-
-                pb.inc(1);
-
-                if !timeout_occurred && next_request_index < args.max_num_completed_requests {
-                    let (prompt, max_tokens) = &prompts[next_request_index as usize];
-                    let model_name = model.clone();
-                    let prompt_clone = prompt.clone();
-                    let client_clone = client.clone();
-                    let tokenizer_clone = loaded_tokenizer.clone();
-
-
-                    let request = BenchmarkRequest {
-                        model: model_name,
-            url: url.to_owned(),
-            api_key: args.api_key.clone(),
-            timeout: timeout_duration,
-                        prompt: prompt_clone,
-                        max_tokens: *max_tokens,
-                        thinking_budget_tokens: args.thinking_budget,
-                        tokenizer: tokenizer_clone,
-                        use_server_token_count,
-                    };
-
-                    in_flight.push(tokio::spawn(run_benchmark_task(
-                        client_clone,
-                        api,
-                        request,
-                    )));
-                    next_request_index += 1;
-                }
-            }
-
-            _ = async {}, if in_flight.is_empty() => {
+        while !*cancel.borrow() && in_flight.len() < args.concurrency as usize {
+            let Some(request) = requests.pop_front() else {
                 break;
-            }
+            };
+            in_flight.spawn(benchmark::capture(
+                client.clone(),
+                args.api,
+                request,
+                timeout,
+                cancel.clone(),
+            ));
         }
-
-        if all_results.len() >= args.max_num_completed_requests as usize {
+        if in_flight.is_empty() && processing.is_empty() {
             break;
         }
-    }
-
-    pb.finish_and_clear();
-
-    let overall_end = Instant::now();
-    let overall_end_unix_ns = unix_time_now_ns();
-    if timeout_occurred {
-        eprintln!(
-            "Benchmark terminated due to timeout after {} seconds.",
-            args.timeout
-        );
-    }
-
-    let mut successful_results = Vec::new();
-    let mut total_output_tokens = 0_u64;
-    let mut total_reasoning_tokens = 0_u64;
-    let num_errors = all_results.iter().filter(|r| r.is_err()).count();
-
-    for br in all_results.iter().flatten() {
-        total_output_tokens += br.output_tokens as u64;
-        total_reasoning_tokens += br.reasoning_tokens as u64;
-        successful_results.push(br.clone());
-    }
-
-    let config = BenchmarkConfig {
-        model: &model,
-        tokenizer: &tokenizer,
-        mean_input_tokens: args.input_tokens,
-        stddev_input_tokens: args.input_tokens_stddev,
-        mean_output_tokens: args.output_cap,
-        stddev_output_tokens: args.output_cap_stddev,
-        num_concurrent_requests: args.num_concurrent_requests,
-    };
-
-    let written_results = write_results_json(
-        &config,
-        &all_results,
-        overall_start,
-        overall_end,
-        overall_start_unix_ns,
-        overall_end_unix_ns,
-    )?;
-
-    match output_format {
-        OutputFormat::Table => {
-            print_summary_to_stdout(
-                &successful_results,
-                num_errors,
-                total_output_tokens,
-                total_reasoning_tokens,
-                overall_start,
-                overall_end,
-            );
+        tokio::select! {
+            Some(captured) = in_flight.join_next(), if !in_flight.is_empty() => {
+                let captured = captured.context("request task failed")?;
+                let tokenizer = Arc::clone(tokenizer);
+                processing.spawn_blocking(move || captured.finish(&tokenizer));
+            }
+            Some(record) = processing.join_next(), if !processing.is_empty() => {
+                let record = record.context("token accounting task failed")?;
+                writer.append(&record).await?;
+                if let Some(error) = &record.error { if pb.is_hidden() { eprintln!("Request {}: {}", record.request_id, error.message); } else { pb.println(format!("Request {}: {}", record.request_id, error.message)); } }
+                records.push(record);
+                pb.inc(1);
+            }
         }
+    }
+    pb.finish_and_clear();
+    Ok(records)
+}
+
+#[tokio::main]
+async fn main() -> Result<ExitCode> {
+    let mut args = Args::parse();
+    if let Some(Command::Update) = args.command {
+        #[cfg(feature = "self-update")]
+        self_update::run_update().await?;
+        #[cfg(not(feature = "self-update"))]
+        eprintln!(
+            "Self-update is only available for standalone installs. Use your package manager to upgrade."
+        );
+        return Ok(ExitCode::SUCCESS);
+    }
+    if let Err(error) = args.validate() {
+        error.exit();
+    }
+    let tokenizer_name = args
+        .tokenizer
+        .get_or_insert_with(|| args.model.clone().unwrap())
+        .clone();
+    let tokenizer = Arc::new(tokens::load(&tokenizer_name)?);
+    let client = client::http_client()?;
+    let generator = PromptGenerator::new(&tokenizer)?;
+    let warmup = prepare(&args, &client, &tokenizer, &generator, Phase::Warmup)?;
+    let measured = prepare(&args, &client, &tokenizer, &generator, Phase::Measurement)?;
+    drop(generator);
+    let mut writer = ResultsWriter::new(None).await?;
+    let (cancel_tx, cancel) = watch::channel(false);
+    let signals = tokio::spawn(async move {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            let _ = cancel_tx.send(true);
+        }
+    });
+    let mut records = run_phase(&args, &client, &tokenizer, warmup, &cancel, &mut writer).await?;
+    records.extend(run_phase(&args, &client, &tokenizer, measured, &cancel, &mut writer).await?);
+    let interrupted = *cancel.borrow();
+    signals.abort();
+    let summary = BenchmarkSummary::new(&args, writer.run_id.clone(), &records, interrupted);
+    writer.finish(&summary).await?;
+    match args.effective_output_format() {
+        OutputFormat::Table => output::print_records(&records),
         OutputFormat::Json => {
-            println!("{}", serde_json::to_string(&written_results.summary)?);
+            let mut stdout = io::stdout().lock();
+            serde_json::to_writer(&mut stdout, &summary)?;
+            writeln!(stdout)?;
         }
         OutputFormat::None => {}
     }
-    Ok(())
+    eprintln!("Results: {}", writer.directory.display());
+    let failed = records
+        .iter()
+        .any(|r| r.status != benchmark::Status::Completed);
+    Ok(if interrupted {
+        ExitCode::from(130)
+    } else if failed {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    })
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,4 +1,6 @@
-use crate::benchmark::BenchmarkResult;
+use crate::args::Args;
+use crate::benchmark::{Phase, RequestRecord, Status, unix_time_ns};
+use anyhow::{Context, Result, anyhow};
 use comfy_table::{
     Attribute, Cell, CellAlignment, Color, ContentArrangement, Table, presets::UTF8_FULL_CONDENSED,
 };
@@ -6,9 +8,9 @@ use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
-use std::fs::{File, create_dir_all};
-use std::io::{Error, ErrorKind, Write};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+use tokio::io::AsyncWriteExt;
 
 pub struct BenchmarkConfig<'a> {
     pub model: &'a str,
@@ -18,10 +20,6 @@ pub struct BenchmarkConfig<'a> {
     pub mean_output_tokens: Option<u32>,
     pub stddev_output_tokens: u32,
     pub num_concurrent_requests: u32,
-}
-
-pub struct WrittenResults {
-    pub summary: BenchmarkSummary,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -77,6 +75,9 @@ pub struct ErrorSummaryEntry {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BenchmarkSummary {
+    pub run_configuration: Option<Value>,
+    pub termination: Option<String>,
+    pub warmup_attempts: Option<usize>,
     pub version: String,
     pub schema_version: String,
     pub llmnop_version: String,
@@ -127,38 +128,6 @@ pub struct BenchmarkSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MetricValue {
-    pub value: Value,
-    pub unit: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RequestError {
-    pub code: i32,
-    #[serde(rename = "type")]
-    pub error_type: String,
-    pub message: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RequestMetadata {
-    pub request_index: usize,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_start_ns: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub request_end_ns: Option<u64>,
-    pub benchmark_phase: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RequestRecord {
-    pub metadata: RequestMetadata,
-    pub metrics: BTreeMap<String, MetricValue>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<RequestError>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Quantiles {
     pub p1: f64,
     pub p5: f64,
@@ -169,21 +138,6 @@ pub struct Quantiles {
     pub p90: f64,
     pub p95: f64,
     pub p99: f64,
-}
-
-fn default_results_dir() -> std::io::Result<PathBuf> {
-    let project_dirs = ProjectDirs::from("", "", "llmnop").ok_or_else(|| {
-        Error::new(
-            ErrorKind::NotFound,
-            "could not resolve platform app data directory for llmnop",
-        )
-    })?;
-
-    if let Some(state_dir) = project_dirs.state_dir() {
-        return Ok(state_dir.join("results"));
-    }
-
-    Ok(project_dirs.data_local_dir().join("results"))
 }
 
 fn benchmark_slug(config: &BenchmarkConfig) -> String {
@@ -198,19 +152,6 @@ fn benchmark_slug(config: &BenchmarkConfig) -> String {
         config.mean_input_tokens,
         output_tokens_str
     )
-}
-
-fn generate_run_id() -> std::io::Result<String> {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_err(|e| Error::other(format!("system clock is before UNIX_EPOCH: {e}")))?;
-    Ok(format!("{}_{:09}", now.as_secs(), now.subsec_nanos()))
-}
-
-fn run_results_dir(base_results_dir: &Path, config: &BenchmarkConfig, run_id: &str) -> PathBuf {
-    base_results_dir.join(benchmark_slug(config)).join(run_id)
 }
 
 pub fn print_summary_to_stdout(
@@ -380,173 +321,6 @@ pub fn print_summary_to_stdout(
     println!("{CYAN}Errors:{RESET} {GREEN}{}{RESET}", num_errors);
 }
 
-pub fn write_results_json(
-    config: &BenchmarkConfig,
-    all_results: &[Result<BenchmarkResult, String>],
-    total_start_time: std::time::Instant,
-    total_end_time: std::time::Instant,
-    start_time_unix_ns: u64,
-    end_time_unix_ns: u64,
-) -> std::io::Result<WrittenResults> {
-    let base_results_dir = default_results_dir()?;
-    let run_id = generate_run_id()?;
-    let run_results_dir = run_results_dir(&base_results_dir, config, &run_id);
-    create_dir_all(&run_results_dir)?;
-
-    let mut total_output_tokens = 0_u64;
-    let mut total_reasoning_tokens = 0_u64;
-    let mut total_input_tokens = 0_u64;
-    let mut successful_results = Vec::new();
-    let mut error_counts_by_message: BTreeMap<String, usize> = BTreeMap::new();
-    let mut per_request_records = Vec::with_capacity(all_results.len());
-
-    for (request_index, result) in all_results.iter().enumerate() {
-        match result {
-            Ok(br) => {
-                total_output_tokens += br.output_tokens as u64;
-                total_reasoning_tokens += br.reasoning_tokens as u64;
-                total_input_tokens += br.input_tokens as u64;
-                successful_results.push(br.clone());
-
-                let mut metrics = BTreeMap::new();
-                metrics.insert(
-                    "time_to_first_token".to_string(),
-                    metric_value_optional_f64(br.ttft.map(|t| t.as_secs_f64() * 1000.0), "ms"),
-                );
-                if let Some(ttfo) = br.ttfo {
-                    metrics.insert(
-                        "time_to_first_output_token".to_string(),
-                        metric_value_f64(ttfo.as_secs_f64() * 1000.0, "ms"),
-                    );
-                }
-                metrics.insert(
-                    "request_latency".to_string(),
-                    metric_value_f64(br.total_latency.as_secs_f64() * 1000.0, "ms"),
-                );
-                metrics.insert(
-                    "inter_token_latency".to_string(),
-                    metric_value_optional_f64(br.inter_token_latency_s.map(|s| s * 1000.0), "ms"),
-                );
-                metrics.insert(
-                    "inter_event_latency".to_string(),
-                    metric_value_optional_f64(br.inter_event_latency_s.map(|s| s * 1000.0), "ms"),
-                );
-                metrics.insert(
-                    "output_token_throughput_per_request".to_string(),
-                    metric_value_optional_f64(br.throughput, "tokens/sec/request"),
-                );
-                metrics.insert(
-                    "input_sequence_length".to_string(),
-                    metric_value_u64(br.input_tokens as u64, "tokens"),
-                );
-                metrics.insert(
-                    "output_token_count".to_string(),
-                    metric_value_u64(br.output_tokens as u64, "tokens"),
-                );
-                metrics.insert(
-                    "reasoning_token_count".to_string(),
-                    metric_value_u64(br.reasoning_tokens as u64, "tokens"),
-                );
-                metrics.insert(
-                    "output_sequence_length".to_string(),
-                    metric_value_u64((br.output_tokens + br.reasoning_tokens) as u64, "tokens"),
-                );
-                if let Some(usage) = &br.provider_usage {
-                    if let Some(tokens) = usage.input_tokens {
-                        metrics.insert(
-                            "usage_input_tokens".to_string(),
-                            metric_value_u64(tokens as u64, "tokens"),
-                        );
-                    }
-                    if let Some(tokens) = usage.output_tokens {
-                        metrics.insert(
-                            "usage_output_tokens".to_string(),
-                            metric_value_u64(tokens as u64, "tokens"),
-                        );
-                    }
-                    if let Some(tokens) = usage.total_tokens {
-                        metrics.insert(
-                            "usage_total_tokens".to_string(),
-                            metric_value_u64(tokens as u64, "tokens"),
-                        );
-                    }
-                    if let Some(tokens) = usage.reasoning_tokens {
-                        metrics.insert(
-                            "usage_reasoning_tokens".to_string(),
-                            metric_value_u64(tokens as u64, "tokens"),
-                        );
-                    }
-                }
-
-                let record = RequestRecord {
-                    metadata: RequestMetadata {
-                        request_index,
-                        request_start_ns: Some(br.request_start_unix_ns),
-                        request_end_ns: Some(br.request_end_unix_ns),
-                        benchmark_phase: "profiling".to_string(),
-                    },
-                    metrics,
-                    error: None,
-                };
-                per_request_records.push(record);
-            }
-            Err(msg) => {
-                *error_counts_by_message.entry(msg.clone()).or_default() += 1;
-
-                let record = RequestRecord {
-                    metadata: RequestMetadata {
-                        request_index,
-                        request_start_ns: None,
-                        request_end_ns: None,
-                        benchmark_phase: "profiling".to_string(),
-                    },
-                    metrics: BTreeMap::new(),
-                    error: Some(RequestError {
-                        code: 1,
-                        error_type: "RequestError".to_string(),
-                        message: msg.clone(),
-                    }),
-                };
-                per_request_records.push(record);
-            }
-        }
-    }
-
-    {
-        let path = run_results_dir.join("individual_responses.jsonl");
-        let mut file = File::create(&path)?;
-        for record in &per_request_records {
-            let line = serde_json::to_string(record)?;
-            file.write_all(line.as_bytes())?;
-            file.write_all(b"\n")?;
-        }
-    }
-
-    let summary = build_summary(
-        &run_id,
-        config,
-        &successful_results,
-        all_results.len(),
-        total_input_tokens,
-        total_output_tokens,
-        total_reasoning_tokens,
-        &error_counts_by_message,
-        total_start_time,
-        total_end_time,
-        start_time_unix_ns,
-        end_time_unix_ns,
-    );
-
-    {
-        let summary_path = run_results_dir.join("summary.json");
-        let mut file = File::create(&summary_path)?;
-        let summary_json = serde_json::to_string_pretty(&summary)?;
-        file.write_all(summary_json.as_bytes())?;
-    }
-
-    Ok(WrittenResults { summary })
-}
-
 #[allow(clippy::too_many_arguments)]
 fn build_summary(
     run_id: &str,
@@ -645,8 +419,11 @@ fn build_summary(
         .collect();
 
     BenchmarkSummary {
-        version: "2026-09-06-streaming.1".to_string(),
-        schema_version: "2.2".to_string(),
+        run_configuration: None,
+        termination: None,
+        warmup_attempts: None,
+        version: "2026-09-06-lifecycle.1".to_string(),
+        schema_version: "2.3".to_string(),
         llmnop_version: env!("CARGO_PKG_VERSION").to_string(),
         benchmark_id: run_id.to_string(),
         benchmark_slug: benchmark_slug(config),
@@ -834,20 +611,6 @@ fn metric_stats_avg_only(unit: &str, avg: f64) -> MetricStats {
     }
 }
 
-fn metric_value_f64(value: f64, unit: &str) -> MetricValue {
-    MetricValue {
-        value: Value::from(value),
-        unit: unit.to_string(),
-    }
-}
-
-fn metric_value_u64(value: u64, unit: &str) -> MetricValue {
-    MetricValue {
-        value: Value::from(value),
-        unit: unit.to_string(),
-    }
-}
-
 fn percentile(sorted_values: &[f64], pct: f64) -> f64 {
     if sorted_values.is_empty() {
         return 0.0;
@@ -856,17 +619,218 @@ fn percentile(sorted_values: &[f64], pct: f64) -> f64 {
     sorted_values[idx]
 }
 
-fn metric_value_optional_f64(value: Option<f64>, unit: &str) -> MetricValue {
-    MetricValue {
-        value: serde_json::json!(value),
-        unit: unit.into(),
+#[derive(Debug, Clone, Serialize)]
+pub struct BenchmarkResult {
+    pub ttft: Option<Duration>,
+    pub ttfo: Option<Duration>,
+    pub total_latency: Duration,
+    pub throughput: Option<f64>,
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+    pub reasoning_tokens: u32,
+    pub inter_token_latency_s: Option<f64>,
+    pub inter_event_latency_s: Option<f64>,
+    pub total_tokens: u32,
+    pub provider_usage: Option<ProviderUsage>,
+    pub request_start_unix_ns: u64,
+    pub request_end_unix_ns: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProviderUsage {
+    pub input_tokens: Option<u32>,
+    pub output_tokens: Option<u32>,
+    pub total_tokens: Option<u32>,
+    pub reasoning_tokens: Option<u32>,
+}
+
+impl BenchmarkResult {
+    pub fn from_record(record: &RequestRecord) -> Result<Self> {
+        if record.status != Status::Completed {
+            return Err(anyhow!(
+                "{}",
+                record
+                    .error
+                    .as_ref()
+                    .map(|e| e.message.as_str())
+                    .unwrap_or("request failed")
+            ));
+        }
+        let m = &record.metrics;
+        let provider_usage = record.provider_usage.as_ref().map(|u| {
+            let n = |a: &str, b: &str| {
+                u.pointer(a)
+                    .or_else(|| u.pointer(b))
+                    .and_then(Value::as_u64)
+                    .and_then(|n| u32::try_from(n).ok())
+            };
+            ProviderUsage {
+                input_tokens: n("/input_tokens", "/prompt_tokens"),
+                output_tokens: n("/output_tokens", "/completion_tokens"),
+                total_tokens: n("/total_tokens", "/total_tokens"),
+                reasoning_tokens: n(
+                    "/output_tokens_details/reasoning_tokens",
+                    "/completion_tokens_details/reasoning_tokens",
+                ),
+            }
+        });
+        let output_tokens = u32::try_from(m.content_tokens.unwrap())?;
+        let reasoning_tokens = u32::try_from(m.reasoning_tokens.unwrap())?;
+        let input_tokens = u32::try_from(m.input_tokens)?;
+        Ok(Self {
+            ttft: m.ttft_ms.map(|n| Duration::from_secs_f64(n / 1000.0)),
+            ttfo: m.ttfo_ms.map(|n| Duration::from_secs_f64(n / 1000.0)),
+            total_latency: record.end.duration_since(record.start),
+            throughput: m.generation_tokens_per_second,
+            input_tokens,
+            output_tokens,
+            reasoning_tokens,
+            inter_token_latency_s: m.mean_inter_token_latency_ms.map(|n| n / 1000.0),
+            inter_event_latency_s: m.mean_inter_event_latency_ms.map(|n| n / 1000.0),
+            total_tokens: input_tokens
+                .checked_add(output_tokens)
+                .and_then(|n| n.checked_add(reasoning_tokens))
+                .ok_or_else(|| anyhow!("token total overflow"))?,
+            provider_usage,
+            request_start_unix_ns: record.start_time_unix_ns,
+            request_end_unix_ns: record.end_time_unix_ns,
+        })
+    }
+}
+
+impl BenchmarkSummary {
+    pub fn new(args: &Args, run_id: String, records: &[RequestRecord], interrupted: bool) -> Self {
+        let measured: Vec<_> = records
+            .iter()
+            .filter(|r| r.phase == Phase::Measurement)
+            .collect();
+        let successful: Vec<_> = measured
+            .iter()
+            .filter_map(|r| BenchmarkResult::from_record(r).ok())
+            .collect();
+        let mut errors = BTreeMap::new();
+        for record in &measured {
+            if let Some(error) = &record.error {
+                *errors.entry(error.message.clone()).or_default() += 1;
+            }
+        }
+        let now = Instant::now();
+        let start = measured.iter().min_by_key(|r| r.start);
+        let end = measured.iter().max_by_key(|r| r.end);
+        let config = BenchmarkConfig {
+            model: args.model.as_deref().unwrap(),
+            tokenizer: args.tokenizer.as_deref().unwrap(),
+            mean_input_tokens: args.input_tokens,
+            stddev_input_tokens: args.input_tokens_stddev,
+            mean_output_tokens: args.output_cap,
+            stddev_output_tokens: args.output_cap_stddev,
+            num_concurrent_requests: args.concurrency,
+        };
+        let mut summary = build_summary(
+            &run_id,
+            &config,
+            &successful,
+            measured.len(),
+            successful.iter().map(|r| u64::from(r.input_tokens)).sum(),
+            successful.iter().map(|r| u64::from(r.output_tokens)).sum(),
+            successful
+                .iter()
+                .map(|r| u64::from(r.reasoning_tokens))
+                .sum(),
+            &errors,
+            start.map_or(now, |r| r.start),
+            end.map_or(now, |r| r.end),
+            start.map_or(0, |r| r.start_time_unix_ns),
+            end.map_or(0, |r| r.end_time_unix_ns),
+        );
+        summary.run_configuration =
+            Some(serde_json::to_value(args).expect("validated configuration is serializable"));
+        summary.termination = Some(
+            if interrupted {
+                "interrupted"
+            } else {
+                "request_count"
+            }
+            .into(),
+        );
+        summary.warmup_attempts = Some(records.iter().filter(|r| r.phase == Phase::Warmup).count());
+        summary
+    }
+}
+
+pub fn print_records(records: &[RequestRecord]) {
+    let measured: Vec<_> = records
+        .iter()
+        .filter(|r| r.phase == Phase::Measurement)
+        .collect();
+    let successful: Vec<_> = measured
+        .iter()
+        .filter_map(|r| BenchmarkResult::from_record(r).ok())
+        .collect();
+    let now = Instant::now();
+    print_summary_to_stdout(
+        &successful,
+        measured.len() - successful.len(),
+        successful.iter().map(|r| u64::from(r.output_tokens)).sum(),
+        successful
+            .iter()
+            .map(|r| u64::from(r.reasoning_tokens))
+            .sum(),
+        measured.iter().map(|r| r.start).min().unwrap_or(now),
+        measured.iter().map(|r| r.end).max().unwrap_or(now),
+    );
+}
+pub struct ResultsWriter {
+    pub directory: PathBuf,
+    pub run_id: String,
+    records: tokio::fs::File,
+}
+
+impl ResultsWriter {
+    pub async fn new(parent: Option<&Path>) -> Result<Self> {
+        let parent = match parent {
+            Some(path) => path.to_owned(),
+            None => {
+                let dirs = ProjectDirs::from("", "", "llmnop")
+                    .context("could not locate results directory")?;
+                dirs.state_dir()
+                    .unwrap_or_else(|| dirs.data_local_dir())
+                    .join("results")
+            }
+        };
+        tokio::fs::create_dir_all(&parent).await?;
+        let run_id = format!("{}_{}", unix_time_ns(), std::process::id());
+        let directory = parent.join(&run_id);
+        tokio::fs::create_dir(&directory)
+            .await
+            .context("could not create run directory")?;
+        let records = tokio::fs::File::create_new(directory.join("requests.jsonl")).await?;
+        Ok(Self {
+            directory,
+            run_id,
+            records,
+        })
+    }
+
+    pub async fn append(&mut self, record: &RequestRecord) -> Result<()> {
+        let mut line = serde_json::to_vec(record)?;
+        line.push(b'\n');
+        self.records.write_all(&line).await?;
+        self.records.flush().await?;
+        Ok(())
+    }
+
+    pub async fn finish(&mut self, summary: &BenchmarkSummary) -> Result<()> {
+        self.records.flush().await?;
+        let path = self.directory.join("summary.json");
+        tokio::fs::write(path, serde_json::to_vec_pretty(summary)?).await?;
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
     use std::time::Duration;
 
     #[test]
@@ -966,38 +930,6 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_run_id_format() {
-        let run_id = generate_run_id().unwrap();
-        let mut parts = run_id.split('_');
-        let secs = parts.next().unwrap();
-        let nanos = parts.next().unwrap();
-
-        assert!(parts.next().is_none());
-        assert_eq!(secs.len(), 10);
-        assert_eq!(nanos.len(), 9);
-        assert!(secs.chars().all(|c| c.is_ascii_digit()));
-        assert!(nanos.chars().all(|c| c.is_ascii_digit()));
-    }
-
-    #[test]
-    fn test_run_results_dir_layout() {
-        let config = BenchmarkConfig {
-            model: "qwen/qwen3-4b-2507",
-            tokenizer: "Qwen/Qwen3-4B",
-            mean_input_tokens: 550,
-            stddev_input_tokens: 0,
-            mean_output_tokens: Some(150),
-            stddev_output_tokens: 0,
-            num_concurrent_requests: 1,
-        };
-        let path = run_results_dir(Path::new("/tmp/results"), &config, "1700000000_123456789");
-        assert_eq!(
-            path,
-            PathBuf::from("/tmp/results/qwen-qwen3-4b-2507_550_150/1700000000_123456789")
-        );
-    }
-
-    #[test]
     fn test_build_summary_has_nested_metrics() {
         let config = BenchmarkConfig {
             model: "qwen/qwen3-4b-2507",
@@ -1020,7 +952,7 @@ mod tests {
             inter_token_latency_s: Some(0.01),
             inter_event_latency_s: Some(0.02),
             total_tokens: 700,
-            provider_usage: Some(crate::benchmark::ProviderUsage {
+            provider_usage: Some(ProviderUsage {
                 input_tokens: Some(550),
                 output_tokens: Some(150),
                 total_tokens: Some(700),
@@ -1045,8 +977,8 @@ mod tests {
             1_700_000_001_000_000_000,
         );
 
-        assert_eq!(summary.schema_version, "2.2");
-        assert_eq!(summary.version, "2026-09-06-streaming.1");
+        assert_eq!(summary.schema_version, "2.3");
+        assert_eq!(summary.version, "2026-09-06-lifecycle.1");
         assert_eq!(summary.request_latency.unit, "ms");
         assert_eq!(
             summary.output_token_throughput_per_request.unit,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,13 +1,10 @@
 use super::*;
 use crate::benchmark::Status;
-use crate::benchmark::{Phase, PreparedRequest};
 use serde_json::Value;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
-use tokio::sync::watch;
 use tokio::task::JoinHandle;
-use tokio::task::JoinSet;
 
 struct Reply {
     status: u16,
@@ -304,6 +301,77 @@ async fn empty_and_tool_only_completions_have_no_text_timings() {
 }
 
 #[tokio::test]
+async fn scheduler_bounds_concurrency_counts_failures_and_exports_recomputable_results() {
+    let mut replies: Vec<_> = (0..5)
+        .map(|_| Reply {
+            status: 200,
+            chunks: vec![(
+                Duration::from_millis(40),
+                format!("{CONTENT}{DONE}").into_bytes(),
+            )],
+        })
+        .collect();
+    replies[1].status = 503;
+    let (url, task, peak) = server(replies).await;
+    let args = Args::parse_from([
+        "llmnop",
+        "--url",
+        &url,
+        "--model",
+        "test",
+        "--requests",
+        "5",
+        "--concurrency",
+        "2",
+        "--quiet",
+    ]);
+    let client = client::http_client().unwrap();
+    let tokenizer = Arc::new(tokens::test_tokenizer());
+    let requests = (0..5)
+        .map(|i| prepared(&client, args::ApiType::Chat, &url, i))
+        .collect();
+    let (_tx, rx) = watch::channel(false);
+    let parent = std::env::temp_dir().join(format!("llmnop-test-{}", benchmark::unix_time_ns()));
+    let mut writer = ResultsWriter::new(Some(&parent)).await.unwrap();
+    let records = run_phase(&args, &client, &tokenizer, requests, &rx, &mut writer)
+        .await
+        .unwrap();
+    assert_eq!(records.len(), 5);
+    assert_eq!(peak.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        records
+            .iter()
+            .filter(|r| r.status == Status::Completed)
+            .count(),
+        4
+    );
+    assert_eq!(
+        records
+            .iter()
+            .filter(|r| r.http_status == Some(503))
+            .count(),
+        1
+    );
+    let mut ids: Vec<_> = records.iter().map(|r| r.request_id).collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![0, 1, 2, 3, 4]);
+    let exported = tokio::fs::read_to_string(writer.directory.join("requests.jsonl"))
+        .await
+        .unwrap();
+    let rows: Vec<Value> = exported
+        .lines()
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+    assert_eq!(rows.len(), 5);
+    assert_eq!(
+        rows.iter().filter(|r| r["status"] == "completed").count(),
+        4
+    );
+    assert_eq!(finish_server(task).await.len(), 5);
+    tokio::fs::remove_dir_all(parent).await.unwrap();
+}
+
+#[tokio::test]
 async fn streamed_refusals_count_as_visible_content() {
     for (api, payload) in [
         (
@@ -332,4 +400,78 @@ async fn streamed_refusals_count_as_visible_content() {
         assert!(record.metrics.ttfo_ms.is_some());
         finish_server(task).await;
     }
+}
+
+#[tokio::test]
+async fn warmup_finishes_before_measurement_and_deadlines_free_slots() {
+    let replies = vec![
+        Reply::sse(&format!("{CONTENT}{DONE}")),
+        Reply::sse(&format!("{CONTENT}{DONE}")),
+        Reply::delayed(CONTENT, DONE),
+        Reply::sse(&format!("{CONTENT}{DONE}")),
+    ];
+    let (url, task, _) = server(replies).await;
+    let args = Args::parse_from([
+        "llmnop",
+        "--url",
+        &url,
+        "--model",
+        "test",
+        "--requests",
+        "2",
+        "--concurrency",
+        "1",
+        "--warmup",
+        "2",
+        "--request-timeout",
+        "0.1",
+    ]);
+    let client = client::http_client().unwrap();
+    let tokenizer = Arc::new(tokens::test_tokenizer());
+    let (_tx, rx) = watch::channel(false);
+    let parent = std::env::temp_dir().join(format!("llmnop-phases-{}", benchmark::unix_time_ns()));
+    let mut writer = ResultsWriter::new(Some(&parent)).await.unwrap();
+    let warmup = (0..2)
+        .map(|i| {
+            let mut r = prepared(&client, args::ApiType::Chat, &url, i);
+            r.phase = Phase::Warmup;
+            r
+        })
+        .collect();
+    let warmup = run_phase(&args, &client, &tokenizer, warmup, &rx, &mut writer)
+        .await
+        .unwrap();
+    assert!(
+        warmup
+            .iter()
+            .all(|r| r.phase == Phase::Warmup && r.status == Status::Completed)
+    );
+    let measured = (2..4)
+        .map(|i| prepared(&client, args::ApiType::Chat, &url, i))
+        .collect();
+    let measured = run_phase(&args, &client, &tokenizer, measured, &rx, &mut writer)
+        .await
+        .unwrap();
+    assert_eq!(measured.len(), 2);
+    assert!(
+        warmup.iter().map(|r| r.end).max().unwrap()
+            <= measured.iter().map(|r| r.start).min().unwrap()
+    );
+    let timed_out = measured
+        .iter()
+        .find(|r| r.status == Status::TimedOut)
+        .unwrap();
+    assert_eq!(timed_out.request_id, 2);
+    assert_eq!(timed_out.metrics.content_tokens, Some(2));
+    assert!(
+        measured
+            .iter()
+            .any(|r| r.request_id == 3 && r.status == Status::Completed)
+    );
+    let exported = tokio::fs::read_to_string(writer.directory.join("requests.jsonl"))
+        .await
+        .unwrap();
+    assert_eq!(exported.lines().count(), 4);
+    assert_eq!(finish_server(task).await.len(), 4);
+    tokio::fs::remove_dir_all(parent).await.unwrap();
 }


### PR DESCRIPTION
## Summary

Make benchmark execution follow an explicit request-attempt budget and concurrency ceiling. Failed attempts count toward the budget and are not retried.

## Changes

- Prepare requests before execution and finish warmup before measurement.
- Replenish request slots without waiting for local output tokenization.
- Apply per-request deadlines and retain partial observations on timeout or cancellation.
- Stop dispatching on interruption, save available results, and return a nonzero exit status for unsuccessful runs.
