### PR TITLE
feat(output): standardize benchmark records and summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ CLI tool for benchmarking streaming LLM inference endpoints.
 
 ## Output Version
 
-- Bump `BenchmarkSummary.version` in `src/output.rs` whenever output fields or semantics change.
+- Bump `BenchmarkSummary.schema_version` in `src/output.rs` whenever released output fields or semantics change. It versions both `summary.json` and `requests.jsonl`; changes within an unreleased schema share its version.
 
 ## Code Style
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+### Added
+
+- Restore `--results-dir` and `--no-progress`. ([#72](https://github.com/jpreagan/llmnop/pull/72))
+
+### Changed
+
+- Rename `individual_responses.jsonl` to `requests.jsonl` and revise the JSON result schema to include separate warmup outcomes, sample counts, and null values for unavailable measurements. Calculate summary statistics from completed measurement requests. ([#72](https://github.com/jpreagan/llmnop/pull/72))
+- Replace `--output-format`, `--json`, and `--quiet` with `--format table|json|none`, and rename `--use-server-token-count` to `--request-usage`. ([#72](https://github.com/jpreagan/llmnop/pull/72))
+
 ## [0.10.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Added
 
-- Restore `--results-dir` and `--no-progress`. ([#72](https://github.com/jpreagan/llmnop/pull/72))
+- Restore `--results-dir`. ([#72](https://github.com/jpreagan/llmnop/pull/72))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Rename `individual_responses.jsonl` to `requests.jsonl` and revise the JSON result schema to include separate warmup outcomes, sample counts, and null values for unavailable measurements. Calculate summary statistics from completed measurement requests. ([#72](https://github.com/jpreagan/llmnop/pull/72))
 - Replace `--output-format`, `--json`, and `--quiet` with `--format table|json|none`, and rename `--use-server-token-count` to `--request-usage`. ([#72](https://github.com/jpreagan/llmnop/pull/72))
 
+### Removed
+
+- Remove the redundant `version` field from summary JSON. Use `schema_version` to identify the output format and `llmnop_version` to identify the producing release. ([#72](https://github.com/jpreagan/llmnop/pull/72))
+
 ## [0.10.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,7 +1297,6 @@ dependencies = [
  "rand 0.10.2",
  "rand_distr",
  "reqwest 0.13.4",
- "sanitize-filename",
  "serde",
  "serde_json",
  "tokenizers",
@@ -2052,15 +2051,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "sanitize-filename"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc984f4f9ceb736a7bb755c3e3bd17dc56370af2600c9780dcc48c66453da34d"
-dependencies = [
- "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ indicatif = "0.18.6"
 rand = "0.10.2"
 rand_distr = "0.6.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "stream", "rustls"] }
-sanitize-filename = "0.6.0"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 tokenizers = { version = "0.23.2", features = ["http", "rustls-tls"] }
@@ -33,7 +32,6 @@ directories = "6.0.0"
 [features]
 self-update = ["dep:axoupdater"]
 
-# The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
 lto = "thin"

--- a/README.md
+++ b/README.md
@@ -43,186 +43,211 @@ brew upgrade llmnop
 ## Quick Start
 
 ```bash
-llmnop --url http://localhost:8000/v1 \
-  --api-key token-abc123 \
-  --model Qwen/Qwen3-4B-Instruct-2507 \
-  --output-cap 150
+llmnop --url http://localhost:11434/v1 \
+  --api responses \
+  --model qwen3.8:27b-mlx \
+  --tokenizer Qwen/Qwen3.8-27B \
+  --input-tokens 550 --output-cap 128 \
+  --requests 20 --concurrency 4
 ```
 
-Results print to stdout and save under the llmnop app results directory:
-
-- macOS: `~/Library/Application Support/llmnop/results`
-- Linux: `${XDG_STATE_HOME:-$HOME/.local/state}/llmnop/results`
-- Windows: `%LOCALAPPDATA%\\llmnop\\data\\results`
+`--url` and `--model` are required for benchmarks. Authentication is optional.
+Use `llmnop --help` for the complete option list. Commands such as `update`
+work without an endpoint; self-update is available in standalone builds.
 
 ## What It Measures
 
-| Metric                  | Description                                                     |
-| ----------------------- | --------------------------------------------------------------- |
-| **TTFT**                | Time to first token - how long until streaming begins           |
-| **TTFO**                | Time to first output token - excludes reasoning/thinking tokens |
-| **Inter-token latency** | Estimated average time between generated tokens                 |
-| **Inter-event latency** | Average gap between streamed events/chunks                      |
-| **Throughput**          | Tokens per second during the generation window                  |
-| **End-to-end latency**  | Total request time from start to finish                         |
+At a specified concurrency, llmnop measures how quickly each request receives
+output and completes, and how much completed work the endpoint delivers.
+Each finished attempt frees a slot for another request. Failures count toward
+`--requests`; there are no automatic retries or redirects. Concurrency is a
+ceiling, with fewer active requests during startup and the final drain.
 
-### Notes
+All API modes stream: `chat` uses `/chat/completions`, `responses` uses
+`/responses`, and `messages` uses `/messages`. Paths are appended to the supplied
+base URL, including any version prefix. The base URL must not contain credentials,
+a query, or a fragment. `--api-key` supplies bearer authentication for Chat and
+Responses, or `x-api-key` authentication for Messages.
 
-- For reasoning models, TTFT includes thinking tokens.
-- TTFO measures time until actual output begins, so it better reflects user-perceived latency.
-- Inter-event latency captures stream chunk cadence.
-- Inter-token latency is token-count based and less sensitive to chunk batching.
+| Measurement | Definition |
+| --- | --- |
+| TTFT | Request start to the first nonempty content or exposed reasoning delta. |
+| TTFO | Request start to the first nonempty content delta. |
+| Request latency | Request start to the API's terminal completion event. |
+| Generation window | First to last nonempty content or reasoning event. |
+| Generation rate | `(generated_tokens - 1) / generation_window_seconds`. |
+| Estimated inter-token latency | `generation_window_ms / (generated_tokens - 1)`. |
+| Mean stream-event gap | Generation window divided by the number of qualifying events minus one. |
+| Longest stream-event gap | Maximum interval between qualifying events. |
+| Input tokens | Locally tokenized prompt text, excluding server-added formatting. |
+| Content tokens | Locally tokenized streamed response content, including streamed refusals. |
+| Exposed reasoning tokens | Locally tokenized streamed reasoning text or summaries. |
+| Generated tokens | Content tokens plus exposed reasoning tokens. |
 
-## Configuration
+Timing starts immediately before sending a prepared HTTP request and includes
+connection setup, endpoint queueing, and network delays. It excludes local prompt
+preparation and waiting for a concurrency slot. A valid terminal event is `[DONE]`
+for Chat, a completed response or supported normal limit/filter termination for
+Responses, and `message_stop` for Messages. EOF alone does not establish success.
+A Chat finish reason is retained while waiting for `[DONE]` and any intervening usage.
 
-### Endpoint
+TTFT and TTFO are client observations of text-bearing events, not individual model
+tokens. A single event can carry multiple tokens or both content and reasoning;
+it counts as one event. Metadata, heartbeats, and tool-call arguments do not count
+as text delivery. Inter-token latency and generation rate are token-normalized
+estimates, not measurements of individual model token intervals. Neither measures
+pure prefill speed or internal reasoning duration.
 
-| Flag            | Description                                            |
-| --------------- | ------------------------------------------------------ |
-| `--url`         | Base URL (e.g., `http://localhost:8000/v1`)            |
-| `--api-key`     | API key for authentication                             |
-| `--model`, `-m` | Model name to benchmark                                |
-| `--api`         | API type: `chat` (default), `responses`, or `messages` |
+Unobservable measurements are JSON `null` and shown as `—` in the table. No content
+means no TTFO. No text events means no TTFT. A single event has a zero generation
+window but no measurable generation rate or event gap. Token-normalized rate and
+latency require at least two locally measured tokens and a positive window.
+Zero observed reasoning tokens does not establish that the model did no reasoning.
+Reasoning representations are recorded in `reasoning_kinds` (`text`, `summary`).
 
-`chat` targets OpenAI's [Chat Completions API](https://platform.openai.com/docs/api-reference/chat). `responses` targets the [Responses API](https://platform.openai.com/docs/api-reference/responses) format, compatible with both OpenAI and [Open Responses](https://huggingface.co/blog/open-responses) servers. `messages` targets Anthropic's [Messages API](https://docs.anthropic.com/en/api/messages).
+## Workload
 
-### Request Shaping
+The sole workload is sampled Shakespeare text. The corpus matches the sonnet corpus
+in [AIPerf](https://github.com/ai-dynamo/aiperf). Nonempty stripped lines are joined
+with spaces in fixed 10,000-character chunks, then tokenized once. Each prompt
+samples a random contiguous token window, wrapping around the corpus as needed.
 
-Control input and output token counts to simulate realistic workloads:
+`--input-tokens` sets the mean token target, and `--input-tokens-stddev` sets its
+standard deviation. With a zero standard deviation the target is fixed. Otherwise,
+lengths are sampled from a normal distribution conditioned on nonnegative values,
+rounded upward, with a minimum of one. Decoded prompts are re-encoded and trimmed
+or topped up to meet the target. Preparation fails after ten unsuccessful
+adjustments rather than silently accepting a different size.
 
-| Flag                       | Default | Description                                               |
-| -------------------------- | ------- | --------------------------------------------------------- |
-| `--input-tokens`      | 550     | Target prompt length in tokens                            |
-| `--input-tokens-stddev`    | 0       | Add variance to input length                              |
-| `--output-cap`     | none    | Mean output token cap to request                          |
-| `--output-cap-stddev`   | 0       | Add variance to output length                             |
-| `--thinking-budget` | none    | Enable Anthropic Messages thinking with this token budget |
+These mechanics follow AIPerf's sonnet generator, with independent checks for
+round-trip length and arbitrary corpus wrapping.
 
-For `--api messages`, `--output-cap` is required so llmnop can set `max_tokens` in the request.
-When `--thinking-budget` is set, it must be at least 1024 and smaller than `--output-cap`.
+`--output-cap` and `--output-cap-stddev` control the requested generation cap,
+not the actual response length. Responses may stop earlier or an endpoint may
+ignore an unsupported parameter. API mappings are:
 
-### Load Testing
+| API | Cap field |
+| --- | --- |
+| Chat | `max_completion_tokens` |
+| Responses | `max_output_tokens` |
+| Messages | `max_tokens` (required) |
 
-| Flag                           | Default | Description                |
-| ------------------------------ | ------- | -------------------------- |
-| `--requests` | 10      | Total requests to complete |
-| `--concurrency`    | 1       | Parallel request count     |
-| `--request-timeout`                    | 600     | Request timeout in seconds |
+Some Ollama Chat implementations ignore `max_completion_tokens`. In that case,
+use Responses or Messages for controlled caps. llmnop records both requested caps
+and actual locally measured counts; it does not infer a limit finish merely from
+those counts. Reasoning's contribution to the provider's cap depends on its API
+and model.
 
-### Tokenization
+`--thinking-budget` enables Messages thinking. It must be at least 1024 and below
+the mean output cap. Every sampled cap also exceeds the thinking budget.
+A nonzero output-cap standard deviation requires an output cap.
 
-By default, llmnop uses a local Hugging Face tokenizer matching `--model` to count measured token metrics.
+`--tokenizer` accepts a Hugging Face identifier or a local `tokenizer.json` file.
+The default identifier is the model name. Tokenizer truncation and padding are
+disabled for measurement. Tokenization of assembled content and reasoning occurs
+after streaming, outside request timing, on blocking workers. A slot is replenished
+without waiting for that tokenization. Text is discarded after counting.
 
-| Flag                       | Description                                                               |
-| -------------------------- | ------------------------------------------------------------------------- |
-| `--tokenizer`              | Use a different HF tokenizer (when model name doesn't match Hugging Face) |
-| `--use-server-token-count` | Request provider-reported usage and record it separately                 |
+## Run Controls
 
-Primary token metrics preserve llmnop's measured semantics: `output_token_count` is visible answer tokens, `reasoning_token_count` is reasoning/thinking tokens, and `output_sequence_length` is their sum. Provider usage fields such as `usage_input_tokens`, `usage_output_tokens`, `usage_total_tokens`, and `usage_reasoning_tokens` are recorded separately when available because provider `usage` may be aggregate or unsplit.
+`--requests` defaults to 10 measured attempts. `--concurrency` defaults to 1.
+`--warmup` defaults to 0 and specifies a total number of additional attempts, using
+the same concurrency ceiling. Warmup finishes before measured requests begin; its
+records and outcome counts are retained separately. Warmup does not guarantee any
+particular server cache state.
 
-### Output
+`--request-timeout` is a per-request deadline in seconds, including the complete
+stream. Fractional seconds are supported. A timed-out request is cancelled locally
+and retains observations received before its deadline. Ctrl-C stops dispatching
+requests, cancels active requests, and writes the available results. The endpoint
+may take additional time to stop its own work after a client disconnects.
 
-| Flag              | Default | Description                                      |
-| ----------------- | ------- | ------------------------------------------------ |
-| `--json`          | false   | Emit benchmark summary JSON to stdout            |
-| `--output-format` | `table` | Stdout output format: `table`, `json`, or `none` |
-| `--quiet`, `-q`   | false   | Suppress stdout output (`--output-format none`)  |
+## Results
 
-## Examples
+Every run writes a unique directory containing:
 
-**Load test with concurrency:**
+- `summary.json`: configuration, outcomes, totals, and statistics.
+- `requests.jsonl`: one measurement record per attempted request, including warmup.
 
-```bash
-llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
-  --model Qwen/Qwen3-4B-Instruct-2507 \
-  --concurrency 10 \
-  --requests 100
-```
-
-**Controlled benchmark with fixed output length:**
-
-```bash
-llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
-  --model Qwen/Qwen3-4B-Instruct-2507 \
-  --output-cap 150
-```
-
-**Responses API:**
-
-```bash
-llmnop --api responses --url http://localhost:8000/v1 --api-key token-abc123 \
-  --model openai/gpt-oss-120b
-```
-
-**Anthropic Messages API:**
-
-```bash
-llmnop --api messages --url http://localhost:8000/v1 --api-key token-abc123 \
-  --model Qwen/Qwen3.6-27B \
-  --output-cap 4096
-```
-
-**JSON stdout for `jq` pipelines:**
-
-```bash
-llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
-  --model Qwen/Qwen3-4B-Instruct-2507 \
-  --output-format json \
-  --requests 1 | jq '.request_latency.p99'
-```
-
-**Custom tokenizer when model name doesn't match Hugging Face:**
-
-```bash
-llmnop --url http://localhost:11434/v1 --api-key ollama
-  --model gpt-oss:20b \
-  --tokenizer openai/gpt-oss-20b
-```
-
-**Cross-model comparison with neutral tokenizer:**
-
-When comparing different models, use a consistent tokenizer so token counts are comparable:
-
-```bash
-llmnop --url http://localhost:8000/v1 --api-key token-abc123 \
-  --model Qwen/Qwen3-4B-Instruct-2507 \
-  --tokenizer hf-internal-testing/llama-tokenizer
-```
-
-## Output Files
-
-Each run writes artifacts to a per-run directory:
+Use `--results-dir` to choose the parent directory. Defaults are:
 
 - macOS: `~/Library/Application Support/llmnop/results`
 - Linux: `${XDG_STATE_HOME:-$HOME/.local/state}/llmnop/results`
-- Windows: `%LOCALAPPDATA%\\llmnop\\data\\results`
+- Windows: the platform-local llmnop data directory, under `results`
 
-Path layout:
+`--format table|json|none` controls stdout only. Progress, errors, and the result
+location go to stderr. `--no-progress` disables progress. Prompt text, response
+text, credentials, and individual event histories are not exported.
 
-- `<results>/<benchmark_slug>/<run_id>/summary.json`
-- `<results>/<benchmark_slug>/<run_id>/individual_responses.jsonl`
+Each request record contains its stable ID and phase, timestamps, elapsed time,
+status, HTTP status, provider finish reason, sampled input target, requested output
+cap, metrics, reasoning representation, provider usage, and error details.
+Records are appended as accounting completes and need not be in request-ID order.
+Failed and cancelled requests retain partial observations; `request_latency_ms`
+is null for these requests, while `elapsed_ms` records time to their terminal outcome.
 
-| File                         | Contents                                                                 |
-| ---------------------------- | ------------------------------------------------------------------------ |
-| `summary.json`               | Aggregated benchmark metrics using nested metric objects (`unit`, stats) |
-| `individual_responses.jsonl` | Per-request records with `metadata`, `metrics`, and `error` (JSONL)      |
+Durations are measured using a monotonic clock. Exported Unix nanosecond timestamps
+share a fixed wall-clock anchor so changes to the system clock during a run cannot
+change durations or cross-request timing. The aggregate measurement interval runs
+from the first measured request's start to the last measured request's termination,
+including failures. Preparation, warmup, and final reporting are excluded.
 
-The summary includes statistical breakdowns for latency and token metrics. `individual_responses.jsonl` stores one request record per line for efficient processing on larger runs.
+Summary metric distributions include **completed measured requests only**. Every
+metric has its own sample count, excluding null observations. Statistics are the
+arithmetic mean, population standard deviation, min/max, and linearly interpolated
+percentiles at indices `p * (n - 1)`. A small sample's p99 is descriptive and does
+not establish a reliable population tail estimate.
 
-## License
+Aggregate request throughput is completed measured requests divided by the
+measurement interval. Aggregate token throughput is locally counted generated
+tokens from those completed requests divided by the same interval. Partial tokens
+from unsuccessful requests remain in the request records and do not enter
+completed-work throughput. Output-limit completions are counted separately from
+failures; empty text completions can still be successful protocol completions.
 
-[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+`--request-usage` asks Chat endpoints to include optional streaming usage. Usage
+returned by any API is always saved separately in `provider_usage`, using that
+API's field names. For Messages, later non-null usage fields update earlier ones. Provider
+counts never replace local counts or enter local rate calculations; reasoning
+subcounts must not be added again to provider totals that already include them.
 
-Sonnet prompts use a fresh random window from the tokenized Shakespeare corpus.
-Prompt text must re-tokenize to its sampled target; generation fails if repair cannot achieve that length.
-The tokenizer may be a Hugging Face identifier or a local tokenizer JSON file.
+Exit status is 0 when all attempted requests complete, 1 for request/setup/export
+failures, 2 for invalid arguments, and 130 for an interrupted run. Results are
+preserved for normal request failures, deadlines, and interruptions.
 
-Streaming clients require an explicit completion event; malformed and truncated streams fail.
-TTFT includes exposed reasoning; TTFO requires visible text. Missing timings are absent,
-and generation metrics exclude both the initial wait and completion metadata after the final text event.
-Token counts use assembled text, with provider usage kept separate. HTTP retries and redirects are disabled.
+### Schema 3 migration
 
-Each measured attempt counts toward `--requests`, including failures; requests are not retried.
-`--concurrency` bounds active requests. `--warmup` is a separate phase excluded from measured results.
-`--request-timeout` limits each request through stream completion. Ctrl-C stops new work and records partial attempts.
-Per-attempt records are flushed to `requests.jsonl`, including statuses, deadlines, and partial observations.
+This overhaul changes the JSON schema to `3.0`. Scalar run values are plain numbers;
+per-request metrics use unit-bearing names and unavailable values are null. Every
+summary distribution includes a sample count. The old `individual_responses.jsonl`
+becomes `requests.jsonl`.
+
+| Previous option | Replacement |
+| --- | --- |
+| `--mean-input-tokens` | `--input-tokens` |
+| `--stddev-input-tokens` | `--input-tokens-stddev` |
+| `--mean-output-tokens` | `--output-cap` |
+| `--stddev-output-tokens` | `--output-cap-stddev` |
+| `--thinking-budget-tokens` | `--thinking-budget` |
+| `--max-num-completed-requests` | `--requests`, `-n` |
+| `--num-concurrent-requests` | `--concurrency`, `-c` |
+| `--timeout` | `--request-timeout` (now a per-request deadline) |
+| `--use-server-token-count` | `--request-usage` |
+| `--output-format`, `--json`, `--quiet` | `--format table|json|none` |
+
+Per-request generation rate now uses `(generated_tokens - 1) / window`, making it
+the reciprocal of estimated inter-token latency. Previous releases used
+`generated_tokens / window`. Aggregate throughput still counts all generated tokens.
+
+## Development
+
+```bash
+cargo fmt --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+```
+
+Tests include local HTTP fixtures for all three streaming APIs, fragmented SSE,
+partial failures, deadlines, cancellation, concurrency, and exported statistics.
+Changes to streaming or measurements should also be exercised against a real
+endpoint using the applicable API modes.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Every run writes a unique directory containing:
 - `summary.json`: configuration, outcomes, totals, and statistics.
 - `requests.jsonl`: one measurement record per attempted request, including warmup.
 
+`summary.json` records `schema_version` for the structure and semantics of both result files, and `llmnop_version` for the release that produced them.
+
 Use `--results-dir` to choose the parent directory. Defaults are:
 
 - macOS: `~/Library/Application Support/llmnop/results`

--- a/README.md
+++ b/README.md
@@ -175,9 +175,7 @@ Use `--results-dir` to choose the parent directory. Defaults are:
 - Linux: `${XDG_STATE_HOME:-$HOME/.local/state}/llmnop/results`
 - Windows: the platform-local llmnop data directory, under `results`
 
-`--format table|json|none` controls stdout only. Progress, errors, and the result
-location go to stderr. `--no-progress` disables progress. Prompt text, response
-text, credentials, and individual event histories are not exported.
+`--format table|json|none` controls stdout only. Progress, errors, and the result location go to stderr. Progress is shown only when stderr is a terminal. Prompt text, response text, credentials, and individual event histories are not exported.
 
 Each request record contains its stable ID and phase, timestamps, elapsed time,
 status, HTTP status, provider finish reason, sampled input target, requested output

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,6 +3,7 @@ use clap::builder::styling::{AnsiColor, Effects};
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use serde::Serialize;
+use std::path::PathBuf;
 use std::time::Duration;
 
 #[derive(Debug, Clone, Copy, ValueEnum, Serialize, PartialEq, Eq)]
@@ -116,34 +117,35 @@ pub struct Args {
         help_heading = "Run"
     )]
     pub request_timeout: f64,
-    #[arg(long, value_enum, default_value = "table", help_heading = "Output")]
-    #[serde(skip)]
-    pub output_format: OutputFormat,
-    #[arg(long, help = "Emit summary JSON", help_heading = "Output")]
-    #[serde(skip)]
-    pub json: bool,
-    #[arg(short = 'q', long, help = "Suppress stdout", help_heading = "Output")]
-    #[serde(skip)]
-    pub quiet: bool,
     #[arg(
         long,
-        help = "Request provider-reported usage",
+        value_enum,
+        default_value = "table",
+        help = "Stdout format",
         help_heading = "Output"
     )]
-    pub use_server_token_count: bool,
+    #[serde(skip)]
+    pub format: OutputFormat,
+    #[arg(
+        long,
+        value_name = "DIR",
+        help = "Parent directory for per-run results [default: platform results directory]",
+        help_heading = "Output"
+    )]
+    #[serde(skip)]
+    pub results_dir: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "Ask the endpoint to include optional token usage",
+        help_heading = "Output"
+    )]
+    pub request_usage: bool,
+    #[arg(long, help = "Suppress progress on stderr", help_heading = "Output")]
+    #[serde(skip)]
+    pub no_progress: bool,
 }
 
 impl Args {
-    pub fn effective_output_format(&self) -> OutputFormat {
-        if self.quiet {
-            OutputFormat::None
-        } else if self.json {
-            OutputFormat::Json
-        } else {
-            self.output_format
-        }
-    }
-
     pub fn validate(&self) -> Result<(), clap::Error> {
         let invalid = |message: &str| Self::command().error(ErrorKind::ValueValidation, message);
         for (name, value) in [("--url", &self.url), ("--model", &self.model)] {

--- a/src/args.rs
+++ b/src/args.rs
@@ -140,9 +140,6 @@ pub struct Args {
         help_heading = "Output"
     )]
     pub request_usage: bool,
-    #[arg(long, help = "Suppress progress on stderr", help_heading = "Output")]
-    #[serde(skip)]
-    pub no_progress: bool,
 }
 
 impl Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ async fn run_phase(
     cancel: &watch::Receiver<bool>,
     writer: &mut ResultsWriter,
 ) -> Result<Vec<RequestRecord>> {
-    let pb = if args.no_progress || !io::stderr().is_terminal() {
+    let pb = if !io::stderr().is_terminal() {
         ProgressBar::hidden()
     } else {
         ProgressBar::new(requests.len() as u64)

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ fn prepare(
             &prompt,
             cap,
             args.thinking_budget,
-            args.use_server_token_count,
+            args.request_usage,
         );
         prepared.push_back(PreparedRequest {
             id: if warmup { index } else { args.warmup + index },
@@ -86,9 +86,7 @@ async fn run_phase(
     cancel: &watch::Receiver<bool>,
     writer: &mut ResultsWriter,
 ) -> Result<Vec<RequestRecord>> {
-    let pb = if matches!(args.effective_output_format(), OutputFormat::None)
-        || !io::stderr().is_terminal()
-    {
+    let pb = if args.no_progress || !io::stderr().is_terminal() {
         ProgressBar::hidden()
     } else {
         ProgressBar::new(requests.len() as u64)
@@ -160,7 +158,7 @@ async fn main() -> Result<ExitCode> {
     let warmup = prepare(&args, &client, &tokenizer, &generator, Phase::Warmup)?;
     let measured = prepare(&args, &client, &tokenizer, &generator, Phase::Measurement)?;
     drop(generator);
-    let mut writer = ResultsWriter::new(None).await?;
+    let mut writer = ResultsWriter::new(args.results_dir.as_deref()).await?;
     let (cancel_tx, cancel) = watch::channel(false);
     let signals = tokio::spawn(async move {
         if tokio::signal::ctrl_c().await.is_ok() {
@@ -173,8 +171,8 @@ async fn main() -> Result<ExitCode> {
     signals.abort();
     let summary = BenchmarkSummary::new(&args, writer.run_id.clone(), &records, interrupted);
     writer.finish(&summary).await?;
-    match args.effective_output_format() {
-        OutputFormat::Table => output::print_records(&records),
+    match args.format {
+        OutputFormat::Table => io::stdout().lock().write_all(summary.table().as_bytes())?,
         OutputFormat::Json => {
             let mut stdout = io::stdout().lock();
             serde_json::to_writer(&mut stdout, &summary)?;
@@ -183,9 +181,7 @@ async fn main() -> Result<ExitCode> {
         OutputFormat::None => {}
     }
     eprintln!("Results: {}", writer.directory.display());
-    let failed = records
-        .iter()
-        .any(|r| r.status != benchmark::Status::Completed);
+    let failed = summary.measurement.unsuccessful() + summary.warmup.unsuccessful() > 0;
     Ok(if interrupted {
         ExitCode::from(130)
     } else if failed {

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,785 +1,277 @@
 use crate::args::Args;
-use crate::benchmark::{Phase, RequestRecord, Status, unix_time_ns};
-use anyhow::{Context, Result, anyhow};
-use comfy_table::{
-    Attribute, Cell, CellAlignment, Color, ContentArrangement, Table, presets::UTF8_FULL_CONDENSED,
-};
+use crate::benchmark::{Metrics, Phase, RequestRecord, Status, unix_time_ns};
+use anyhow::{Context, Result};
+use comfy_table::{Table, presets::UTF8_FULL_CONDENSED};
 use directories::ProjectDirs;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
 use tokio::io::AsyncWriteExt;
 
-pub struct BenchmarkConfig<'a> {
-    pub model: &'a str,
-    pub tokenizer: &'a str,
-    pub mean_input_tokens: u32,
-    pub stddev_input_tokens: u32,
-    pub mean_output_tokens: Option<u32>,
-    pub stddev_output_tokens: u32,
-    pub num_concurrent_requests: u32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SummaryInputConfig {
-    pub model: String,
-    pub tokenizer: String,
-    pub mean_input_tokens: u32,
-    pub stddev_input_tokens: u32,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mean_output_tokens: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stddev_output_tokens: Option<u32>,
-    pub num_concurrent_requests: u32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize)]
 pub struct MetricStats {
-    pub unit: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub avg: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub p1: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub p5: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub p10: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub p25: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub p50: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub p75: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub p90: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub p95: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub p99: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub min: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub std: Option<f64>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ErrorSummaryEntry {
-    pub code: i32,
-    pub message: String,
     pub count: usize,
+    pub mean: Option<f64>,
+    pub stddev: Option<f64>,
+    pub min: Option<f64>,
+    pub p50: Option<f64>,
+    pub p90: Option<f64>,
+    pub p95: Option<f64>,
+    pub p99: Option<f64>,
+    pub max: Option<f64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BenchmarkSummary {
-    pub run_configuration: Option<Value>,
-    pub termination: Option<String>,
-    pub warmup_attempts: Option<usize>,
-    pub version: String,
-    pub schema_version: String,
-    pub llmnop_version: String,
-    pub benchmark_id: String,
-    pub benchmark_slug: String,
-    pub start_time_unix_ns: u64,
-    pub end_time_unix_ns: u64,
-    pub input_config: SummaryInputConfig,
-
-    pub benchmark_duration: MetricStats,
-    pub request_count: MetricStats,
-    pub successful_request_count: MetricStats,
-    pub error_request_count: MetricStats,
-    pub error_rate: MetricStats,
-    pub request_throughput: MetricStats,
-
-    pub request_latency: MetricStats,
-    pub time_to_first_token: MetricStats,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub time_to_first_output_token: Option<MetricStats>,
-    pub inter_token_latency: MetricStats,
-    pub inter_event_latency: MetricStats,
-
-    pub output_token_throughput_per_request: MetricStats,
-    pub output_token_throughput: MetricStats,
-    pub total_token_throughput: MetricStats,
-
-    pub input_sequence_length: MetricStats,
-    pub output_token_count: MetricStats,
-    pub reasoning_token_count: MetricStats,
-    pub output_sequence_length: MetricStats,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub usage_input_tokens: Option<MetricStats>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub usage_output_tokens: Option<MetricStats>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub usage_total_tokens: Option<MetricStats>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub usage_reasoning_tokens: Option<MetricStats>,
-
-    pub total_input_tokens: MetricStats,
-    pub total_output_tokens: MetricStats,
-    pub total_reasoning_tokens: MetricStats,
-    pub total_output_sequence_tokens: MetricStats,
-
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub error_summary: Vec<ErrorSummaryEntry>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Quantiles {
-    pub p1: f64,
-    pub p5: f64,
-    pub p10: f64,
-    pub p25: f64,
-    pub p50: f64,
-    pub p75: f64,
-    pub p90: f64,
-    pub p95: f64,
-    pub p99: f64,
-}
-
-fn benchmark_slug(config: &BenchmarkConfig) -> String {
-    let output_tokens_str = config
-        .mean_output_tokens
-        .map(|v| v.to_string())
-        .unwrap_or_else(|| "none".to_string());
-
-    format!(
-        "{}_{}_{}",
-        sanitize_filename::sanitize(config.model.replace(['/', '.'], "-")),
-        config.mean_input_tokens,
-        output_tokens_str
-    )
-}
-
-pub fn print_summary_to_stdout(
-    successful_results: &[BenchmarkResult],
-    num_errors: usize,
-    total_output_tokens: u64,
-    total_reasoning_tokens: u64,
-    start_time: std::time::Instant,
-    end_time: std::time::Instant,
-) {
-    let total_time_s = end_time.duration_since(start_time).as_secs_f64();
-
-    let mut inter_token_vec = Vec::new();
-    let mut inter_event_vec = Vec::new();
-    let mut ttft_vec = Vec::new();
-    let mut ttfo_vec = Vec::new();
-    let mut e2e_vec = Vec::new();
-    let mut throughput_vec = Vec::new();
-    let mut in_tokens_vec = Vec::new();
-    let mut reasoning_tokens_vec = Vec::new();
-    let mut out_tokens_vec = Vec::new();
-    let mut total_tokens_vec = Vec::new();
-
-    for br in successful_results {
-        inter_token_vec.extend(br.inter_token_latency_s);
-        inter_event_vec.extend(br.inter_event_latency_s);
-        ttft_vec.extend(br.ttft.map(|t| t.as_secs_f64()));
-        if let Some(ttfo) = br.ttfo {
-            ttfo_vec.push(ttfo.as_secs_f64());
-        }
-        e2e_vec.push(br.total_latency.as_secs_f64());
-        throughput_vec.extend(br.throughput);
-        in_tokens_vec.push(br.input_tokens as f64);
-        reasoning_tokens_vec.push(br.reasoning_tokens as f64);
-        out_tokens_vec.push(br.output_tokens as f64);
-        total_tokens_vec.push(br.total_tokens as f64);
-    }
-
-    let inter_stats = compute_stats(&inter_token_vec);
-    let inter_event_stats = compute_stats(&inter_event_vec);
-    let ttft_stats = compute_stats(&ttft_vec);
-    let ttfo_stats = compute_stats(&ttfo_vec);
-    let e2e_stats = compute_stats(&e2e_vec);
-    let thr_stats = compute_stats(&throughput_vec);
-    let in_stats = compute_stats(&in_tokens_vec);
-    let reasoning_stats = compute_stats(&reasoning_tokens_vec);
-    let out_stats = compute_stats(&out_tokens_vec);
-    let total_stats = compute_stats(&total_tokens_vec);
-
-    let mut table = Table::new();
-    table.load_style(UTF8_FULL_CONDENSED);
-    table.set_content_arrangement(ContentArrangement::Dynamic);
-    table.set_header(vec![
-        Cell::new("Metric").add_attribute(Attribute::Bold),
-        Cell::new("avg").add_attribute(Attribute::Bold),
-        Cell::new("min").add_attribute(Attribute::Bold),
-        Cell::new("max").add_attribute(Attribute::Bold),
-        Cell::new("p99").add_attribute(Attribute::Bold),
-        Cell::new("p90").add_attribute(Attribute::Bold),
-        Cell::new("p50").add_attribute(Attribute::Bold),
-        Cell::new("std").add_attribute(Attribute::Bold),
-    ]);
-
-    fn fmt_ms(s: f64) -> String {
-        format!("{:.2}", s * 1000.0)
-    }
-
-    fn fmt_f64(v: f64) -> String {
-        format!("{:.2}", v)
-    }
-
-    fn fmt_int(v: f64) -> String {
-        format!("{}", v as u32)
-    }
-
-    fn add_row(table: &mut Table, name: &str, stats: &StatSet, fmt: fn(f64) -> String) {
-        table.add_row(vec![
-            Cell::new(name).fg(Color::Cyan),
-            Cell::new(fmt(stats.mean))
-                .set_alignment(CellAlignment::Right)
-                .fg(Color::Green),
-            Cell::new(fmt(stats.min))
-                .set_alignment(CellAlignment::Right)
-                .fg(Color::Green),
-            Cell::new(fmt(stats.max))
-                .set_alignment(CellAlignment::Right)
-                .fg(Color::Green),
-            Cell::new(fmt(stats.quantiles.p99))
-                .set_alignment(CellAlignment::Right)
-                .fg(Color::Green),
-            Cell::new(fmt(stats.quantiles.p90))
-                .set_alignment(CellAlignment::Right)
-                .fg(Color::Green),
-            Cell::new(fmt(stats.quantiles.p50))
-                .set_alignment(CellAlignment::Right)
-                .fg(Color::Green),
-            Cell::new(fmt(stats.stddev))
-                .set_alignment(CellAlignment::Right)
-                .fg(Color::Green),
-        ]);
-    }
-
-    add_row(&mut table, "Inter Token Latency (ms)", &inter_stats, fmt_ms);
-    add_row(
-        &mut table,
-        "Inter Event Latency (ms)",
-        &inter_event_stats,
-        fmt_ms,
-    );
-    add_row(&mut table, "Time to First Token (ms)", &ttft_stats, fmt_ms);
-    if !ttfo_vec.is_empty() {
-        add_row(
-            &mut table,
-            "Time to First Output Token (ms)",
-            &ttfo_stats,
-            fmt_ms,
-        );
-    }
-    add_row(&mut table, "End to End Latency (ms)", &e2e_stats, fmt_ms);
-    add_row(
-        &mut table,
-        "Output Throughput Per Request (tokens/s)",
-        &thr_stats,
-        fmt_f64,
-    );
-    add_row(&mut table, "Input Tokens", &in_stats, fmt_int);
-    if reasoning_stats.max > 0.0 {
-        add_row(&mut table, "Reasoning Tokens", &reasoning_stats, fmt_int);
-    }
-    add_row(&mut table, "Output Tokens", &out_stats, fmt_int);
-    add_row(&mut table, "Total Tokens", &total_stats, fmt_int);
-
-    println!();
-    println!("{table}");
-
-    let total_generated_tokens = total_output_tokens + total_reasoning_tokens;
-    let overall_output_throughput = if total_time_s > 0.0 {
-        total_generated_tokens as f64 / total_time_s
-    } else {
-        0.0
-    };
-
-    let num_completed_requests = successful_results.len();
-    let completed_requests_per_min = if total_time_s > 0.0 {
-        num_completed_requests as f64 / total_time_s * 60.0
-    } else {
-        0.0
-    };
-
-    const CYAN: &str = "\x1b[36m";
-    const GREEN: &str = "\x1b[32m";
-    const RESET: &str = "\x1b[0m";
-
-    println!();
-    println!(
-        "{CYAN}Overall Output Throughput:{RESET} {GREEN}{:.2} tokens/s{RESET}",
-        overall_output_throughput
-    );
-    println!(
-        "{CYAN}Completed Requests:{RESET} {GREEN}{}{RESET}",
-        num_completed_requests
-    );
-    println!(
-        "{CYAN}Requests Per Minute:{RESET} {GREEN}{:.2}{RESET}",
-        completed_requests_per_min
-    );
-    println!("{CYAN}Errors:{RESET} {GREEN}{}{RESET}", num_errors);
-}
-
-#[allow(clippy::too_many_arguments)]
-fn build_summary(
-    run_id: &str,
-    config: &BenchmarkConfig,
-    successful_results: &[BenchmarkResult],
-    num_requests_started: usize,
-    total_input_tokens: u64,
-    total_output_tokens: u64,
-    total_reasoning_tokens: u64,
-    error_counts_by_message: &BTreeMap<String, usize>,
-    start_time: std::time::Instant,
-    end_time: std::time::Instant,
-    start_time_unix_ns: u64,
-    end_time_unix_ns: u64,
-) -> BenchmarkSummary {
-    let total_time_s = end_time.duration_since(start_time).as_secs_f64();
-
-    let mut request_latency_ms = Vec::new();
-    let mut ttft_ms = Vec::new();
-    let mut ttfo_ms = Vec::new();
-    let mut inter_token_ms = Vec::new();
-    let mut inter_event_ms = Vec::new();
-    let mut throughput_per_request = Vec::new();
-    let mut in_tokens = Vec::new();
-    let mut out_tokens = Vec::new();
-    let mut reasoning_tokens = Vec::new();
-    let mut output_sequence_tokens = Vec::new();
-    let mut usage_input_tokens = Vec::new();
-    let mut usage_output_tokens = Vec::new();
-    let mut usage_total_tokens = Vec::new();
-    let mut usage_reasoning_tokens = Vec::new();
-
-    for br in successful_results {
-        request_latency_ms.push(br.total_latency.as_secs_f64() * 1000.0);
-        ttft_ms.extend(br.ttft.map(|t| t.as_secs_f64() * 1000.0));
-        if let Some(ttfo) = br.ttfo {
-            ttfo_ms.push(ttfo.as_secs_f64() * 1000.0);
-        }
-        inter_token_ms.extend(br.inter_token_latency_s.map(|s| s * 1000.0));
-        inter_event_ms.extend(br.inter_event_latency_s.map(|s| s * 1000.0));
-        throughput_per_request.extend(br.throughput);
-        in_tokens.push(br.input_tokens as f64);
-        out_tokens.push(br.output_tokens as f64);
-        reasoning_tokens.push(br.reasoning_tokens as f64);
-        output_sequence_tokens.push((br.output_tokens + br.reasoning_tokens) as f64);
-        if let Some(usage) = &br.provider_usage {
-            if let Some(tokens) = usage.input_tokens {
-                usage_input_tokens.push(tokens as f64);
-            }
-            if let Some(tokens) = usage.output_tokens {
-                usage_output_tokens.push(tokens as f64);
-            }
-            if let Some(tokens) = usage.total_tokens {
-                usage_total_tokens.push(tokens as f64);
-            }
-            if let Some(tokens) = usage.reasoning_tokens {
-                usage_reasoning_tokens.push(tokens as f64);
-            }
-        }
-    }
-
-    let completed_requests = successful_results.len();
-    let num_errors = num_requests_started.saturating_sub(completed_requests);
-    let error_rate = if num_requests_started == 0 {
-        0.0
-    } else {
-        num_errors as f64 / num_requests_started as f64
-    };
-
-    let request_throughput = if total_time_s > 0.0 {
-        completed_requests as f64 / total_time_s
-    } else {
-        0.0
-    };
-
-    let total_output_sequence_tokens = total_output_tokens + total_reasoning_tokens;
-    let output_token_throughput = if total_time_s > 0.0 {
-        total_output_sequence_tokens as f64 / total_time_s
-    } else {
-        0.0
-    };
-
-    let total_token_throughput = if total_time_s > 0.0 {
-        (total_input_tokens + total_output_sequence_tokens) as f64 / total_time_s
-    } else {
-        0.0
-    };
-
-    let error_summary = error_counts_by_message
-        .iter()
-        .map(|(message, count)| ErrorSummaryEntry {
-            code: 1,
-            message: message.clone(),
-            count: *count,
-        })
-        .collect();
-
-    BenchmarkSummary {
-        run_configuration: None,
-        termination: None,
-        warmup_attempts: None,
-        version: "2026-09-06-lifecycle.1".to_string(),
-        schema_version: "2.3".to_string(),
-        llmnop_version: env!("CARGO_PKG_VERSION").to_string(),
-        benchmark_id: run_id.to_string(),
-        benchmark_slug: benchmark_slug(config),
-        start_time_unix_ns,
-        end_time_unix_ns,
-        input_config: SummaryInputConfig {
-            model: config.model.to_string(),
-            tokenizer: config.tokenizer.to_string(),
-            mean_input_tokens: config.mean_input_tokens,
-            stddev_input_tokens: config.stddev_input_tokens,
-            mean_output_tokens: config.mean_output_tokens,
-            stddev_output_tokens: config
-                .mean_output_tokens
-                .map(|_| config.stddev_output_tokens),
-            num_concurrent_requests: config.num_concurrent_requests,
-        },
-        benchmark_duration: metric_stats_avg_only("sec", total_time_s),
-        request_count: metric_stats_avg_only("requests", num_requests_started as f64),
-        successful_request_count: metric_stats_avg_only("requests", completed_requests as f64),
-        error_request_count: metric_stats_avg_only("requests", num_errors as f64),
-        error_rate: metric_stats_avg_only("ratio", error_rate),
-        request_throughput: metric_stats_avg_only("requests/sec", request_throughput),
-        request_latency: metric_stats_from_values(&request_latency_ms, "ms"),
-        time_to_first_token: metric_stats_from_values(&ttft_ms, "ms"),
-        time_to_first_output_token: if ttfo_ms.is_empty() {
-            None
-        } else {
-            Some(metric_stats_from_values(&ttfo_ms, "ms"))
-        },
-        inter_token_latency: metric_stats_from_values(&inter_token_ms, "ms"),
-        inter_event_latency: metric_stats_from_values(&inter_event_ms, "ms"),
-        output_token_throughput_per_request: metric_stats_from_values(
-            &throughput_per_request,
-            "tokens/sec/request",
-        ),
-        output_token_throughput: metric_stats_avg_only("tokens/sec", output_token_throughput),
-        total_token_throughput: metric_stats_avg_only("tokens/sec", total_token_throughput),
-        input_sequence_length: metric_stats_from_values(&in_tokens, "tokens"),
-        output_token_count: metric_stats_from_values(&out_tokens, "tokens"),
-        reasoning_token_count: metric_stats_from_values(&reasoning_tokens, "tokens"),
-        output_sequence_length: metric_stats_from_values(&output_sequence_tokens, "tokens"),
-        usage_input_tokens: metric_stats_optional(&usage_input_tokens, "tokens"),
-        usage_output_tokens: metric_stats_optional(&usage_output_tokens, "tokens"),
-        usage_total_tokens: metric_stats_optional(&usage_total_tokens, "tokens"),
-        usage_reasoning_tokens: metric_stats_optional(&usage_reasoning_tokens, "tokens"),
-        total_input_tokens: metric_stats_avg_only("tokens", total_input_tokens as f64),
-        total_output_tokens: metric_stats_avg_only("tokens", total_output_tokens as f64),
-        total_reasoning_tokens: metric_stats_avg_only("tokens", total_reasoning_tokens as f64),
-        total_output_sequence_tokens: metric_stats_avg_only(
-            "tokens",
-            total_output_sequence_tokens as f64,
-        ),
-        error_summary,
-    }
-}
-
-#[derive(Default)]
-struct StatSet {
-    quantiles: Quantiles,
-    mean: f64,
-    min: f64,
-    max: f64,
-    stddev: f64,
-}
-
-impl Default for Quantiles {
-    fn default() -> Self {
-        Self {
-            p1: 0.0,
-            p5: 0.0,
-            p10: 0.0,
-            p25: 0.0,
-            p50: 0.0,
-            p75: 0.0,
-            p90: 0.0,
-            p95: 0.0,
-            p99: 0.0,
-        }
-    }
-}
-
-fn compute_stats(values: &[f64]) -> StatSet {
-    if values.is_empty() {
-        return StatSet::default();
-    }
-
-    let mut sorted = values.to_vec();
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-
-    let mean = sorted.iter().sum::<f64>() / sorted.len() as f64;
-    let min = sorted[0];
-    let max = sorted[sorted.len() - 1];
-    let stddev = if sorted.len() > 1 {
-        let var =
-            sorted.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / (sorted.len() as f64 - 1.0);
-        var.sqrt()
-    } else {
-        0.0
-    };
-
-    let quantiles = Quantiles {
-        p1: percentile(&sorted, 0.01),
-        p5: percentile(&sorted, 0.05),
-        p10: percentile(&sorted, 0.10),
-        p25: percentile(&sorted, 0.25),
-        p50: percentile(&sorted, 0.50),
-        p75: percentile(&sorted, 0.75),
-        p90: percentile(&sorted, 0.90),
-        p95: percentile(&sorted, 0.95),
-        p99: percentile(&sorted, 0.99),
-    };
-
-    StatSet {
-        quantiles,
-        mean,
-        min,
-        max,
-        stddev,
-    }
-}
-
-fn metric_stats_from_values(values: &[f64], unit: &str) -> MetricStats {
-    if values.is_empty() {
-        return MetricStats {
-            unit: unit.to_string(),
-            avg: None,
-            p1: None,
-            p5: None,
-            p10: None,
-            p25: None,
-            p50: None,
-            p75: None,
-            p90: None,
-            p95: None,
-            p99: None,
-            min: None,
-            max: None,
-            std: None,
-        };
-    }
-
-    let stats = compute_stats(values);
-    MetricStats {
-        unit: unit.to_string(),
-        avg: Some(stats.mean),
-        p1: Some(stats.quantiles.p1),
-        p5: Some(stats.quantiles.p5),
-        p10: Some(stats.quantiles.p10),
-        p25: Some(stats.quantiles.p25),
-        p50: Some(stats.quantiles.p50),
-        p75: Some(stats.quantiles.p75),
-        p90: Some(stats.quantiles.p90),
-        p95: Some(stats.quantiles.p95),
-        p99: Some(stats.quantiles.p99),
-        min: Some(stats.min),
-        max: Some(stats.max),
-        std: Some(stats.stddev),
-    }
-}
-
-fn metric_stats_optional(values: &[f64], unit: &str) -> Option<MetricStats> {
-    if values.is_empty() {
-        None
-    } else {
-        Some(metric_stats_from_values(values, unit))
-    }
-}
-
-fn metric_stats_avg_only(unit: &str, avg: f64) -> MetricStats {
-    MetricStats {
-        unit: unit.to_string(),
-        avg: Some(avg),
-        p1: None,
-        p5: None,
-        p10: None,
-        p25: None,
-        p50: None,
-        p75: None,
-        p90: None,
-        p95: None,
-        p99: None,
-        min: None,
-        max: None,
-        std: None,
-    }
-}
-
-fn percentile(sorted_values: &[f64], pct: f64) -> f64 {
-    if sorted_values.is_empty() {
-        return 0.0;
-    }
-    let idx = ((sorted_values.len() - 1) as f64 * pct).floor() as usize;
-    sorted_values[idx]
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct BenchmarkResult {
-    pub ttft: Option<Duration>,
-    pub ttfo: Option<Duration>,
-    pub total_latency: Duration,
-    pub throughput: Option<f64>,
-    pub input_tokens: u32,
-    pub output_tokens: u32,
-    pub reasoning_tokens: u32,
-    pub inter_token_latency_s: Option<f64>,
-    pub inter_event_latency_s: Option<f64>,
-    pub total_tokens: u32,
-    pub provider_usage: Option<ProviderUsage>,
-    pub request_start_unix_ns: u64,
-    pub request_end_unix_ns: u64,
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub struct ProviderUsage {
-    pub input_tokens: Option<u32>,
-    pub output_tokens: Option<u32>,
-    pub total_tokens: Option<u32>,
-    pub reasoning_tokens: Option<u32>,
-}
-
-impl BenchmarkResult {
-    pub fn from_record(record: &RequestRecord) -> Result<Self> {
-        if record.status != Status::Completed {
-            return Err(anyhow!(
-                "{}",
-                record
-                    .error
-                    .as_ref()
-                    .map(|e| e.message.as_str())
-                    .unwrap_or("request failed")
-            ));
-        }
-        let m = &record.metrics;
-        let provider_usage = record.provider_usage.as_ref().map(|u| {
-            let n = |a: &str, b: &str| {
-                u.pointer(a)
-                    .or_else(|| u.pointer(b))
-                    .and_then(Value::as_u64)
-                    .and_then(|n| u32::try_from(n).ok())
-            };
-            ProviderUsage {
-                input_tokens: n("/input_tokens", "/prompt_tokens"),
-                output_tokens: n("/output_tokens", "/completion_tokens"),
-                total_tokens: n("/total_tokens", "/total_tokens"),
-                reasoning_tokens: n(
-                    "/output_tokens_details/reasoning_tokens",
-                    "/completion_tokens_details/reasoning_tokens",
-                ),
-            }
+impl MetricStats {
+    fn new(mut values: Vec<f64>) -> Self {
+        values.sort_unstable_by(f64::total_cmp);
+        let count = values.len();
+        let mean = (count > 0).then(|| values.iter().sum::<f64>() / count as f64);
+        let stddev = mean.map(|mean| {
+            (values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / count as f64).sqrt()
         });
-        let output_tokens = u32::try_from(m.content_tokens.unwrap())?;
-        let reasoning_tokens = u32::try_from(m.reasoning_tokens.unwrap())?;
-        let input_tokens = u32::try_from(m.input_tokens)?;
-        Ok(Self {
-            ttft: m.ttft_ms.map(|n| Duration::from_secs_f64(n / 1000.0)),
-            ttfo: m.ttfo_ms.map(|n| Duration::from_secs_f64(n / 1000.0)),
-            total_latency: record.end.duration_since(record.start),
-            throughput: m.generation_tokens_per_second,
-            input_tokens,
-            output_tokens,
-            reasoning_tokens,
-            inter_token_latency_s: m.mean_inter_token_latency_ms.map(|n| n / 1000.0),
-            inter_event_latency_s: m.mean_inter_event_latency_ms.map(|n| n / 1000.0),
-            total_tokens: input_tokens
-                .checked_add(output_tokens)
-                .and_then(|n| n.checked_add(reasoning_tokens))
-                .ok_or_else(|| anyhow!("token total overflow"))?,
-            provider_usage,
-            request_start_unix_ns: record.start_time_unix_ns,
-            request_end_unix_ns: record.end_time_unix_ns,
-        })
+        let percentile = |p: f64| {
+            if count == 0 {
+                return None;
+            }
+            let index = p * (count - 1) as f64;
+            let lo = index.floor() as usize;
+            let hi = index.ceil() as usize;
+            Some(values[lo] + (values[hi] - values[lo]) * index.fract())
+        };
+        Self {
+            count,
+            mean,
+            stddev,
+            min: values.first().copied(),
+            p50: percentile(0.5),
+            p90: percentile(0.9),
+            p95: percentile(0.95),
+            p99: percentile(0.99),
+            max: values.last().copied(),
+        }
     }
 }
 
-impl BenchmarkSummary {
-    pub fn new(args: &Args, run_id: String, records: &[RequestRecord], interrupted: bool) -> Self {
+#[derive(Debug, Default, Serialize)]
+pub struct Counts {
+    pub started: usize,
+    pub completed: usize,
+    pub failed: usize,
+    pub timed_out: usize,
+    pub cancelled: usize,
+    pub completed_at_output_limit: usize,
+    pub completed_with_no_text: usize,
+}
+
+impl Counts {
+    fn from_records(records: &[&RequestRecord]) -> Self {
+        let mut counts = Self::default();
+        for r in records {
+            counts.started += 1;
+            match r.status {
+                Status::Completed => {
+                    counts.completed += 1;
+                    counts.completed_at_output_limit += usize::from(matches!(
+                        r.finish_reason.as_deref(),
+                        Some("length" | "max_tokens" | "max_output_tokens")
+                    ));
+                    counts.completed_with_no_text += usize::from(r.metrics.delivery_events == 0);
+                }
+                Status::Failed => counts.failed += 1,
+                Status::TimedOut => counts.timed_out += 1,
+                Status::Cancelled => counts.cancelled += 1,
+            }
+        }
+        counts
+    }
+
+    pub fn unsuccessful(&self) -> usize {
+        self.failed + self.timed_out + self.cancelled
+    }
+}
+
+#[derive(Debug, Default, Serialize)]
+pub struct TokenTotals {
+    pub input_tokens: u64,
+    pub content_tokens: u64,
+    pub reasoning_tokens: u64,
+    pub generated_tokens: u64,
+}
+
+#[derive(Serialize)]
+pub struct BenchmarkSummary<'a> {
+    pub version: &'static str,
+    pub schema_version: &'static str,
+    pub llmnop_version: &'static str,
+    pub run_id: String,
+    pub configuration: &'a Args,
+    pub termination: &'static str,
+    pub start_time_unix_ns: Option<u64>,
+    pub end_time_unix_ns: Option<u64>,
+    pub measurement_duration_ms: Option<f64>,
+    pub measurement: Counts,
+    pub warmup: Counts,
+    pub completion_fraction: Option<f64>,
+    pub completed_requests_per_second: Option<f64>,
+    pub completed_generated_tokens_per_second: Option<f64>,
+    pub metric_population: &'static str,
+    pub metrics: BTreeMap<&'static str, MetricStats>,
+    pub completed_token_totals: TokenTotals,
+    pub errors: BTreeMap<&'static str, usize>,
+}
+
+fn metric_values(m: &Metrics) -> [(&'static str, Option<f64>); 13] {
+    [
+        ("request_latency_ms", m.request_latency_ms),
+        ("ttft_ms", m.ttft_ms),
+        ("ttfo_ms", m.ttfo_ms),
+        ("generation_window_ms", m.generation_window_ms),
+        (
+            "generation_tokens_per_second",
+            m.generation_tokens_per_second,
+        ),
+        ("mean_inter_token_latency_ms", m.mean_inter_token_latency_ms),
+        ("mean_inter_event_latency_ms", m.mean_inter_event_latency_ms),
+        ("max_inter_event_latency_ms", m.max_inter_event_latency_ms),
+        ("input_tokens", Some(m.input_tokens as f64)),
+        ("content_tokens", m.content_tokens.map(|n| n as f64)),
+        ("reasoning_tokens", m.reasoning_tokens.map(|n| n as f64)),
+        ("generated_tokens", m.generated_tokens.map(|n| n as f64)),
+        ("delivery_events", Some(m.delivery_events as f64)),
+    ]
+}
+
+impl<'a> BenchmarkSummary<'a> {
+    pub fn new(
+        args: &'a Args,
+        run_id: String,
+        records: &[RequestRecord],
+        interrupted: bool,
+    ) -> Self {
         let measured: Vec<_> = records
             .iter()
             .filter(|r| r.phase == Phase::Measurement)
             .collect();
-        let successful: Vec<_> = measured
+        let warmup: Vec<_> = records
             .iter()
-            .filter_map(|r| BenchmarkResult::from_record(r).ok())
+            .filter(|r| r.phase == Phase::Warmup)
             .collect();
-        let mut errors = BTreeMap::new();
-        for record in &measured {
-            if let Some(error) = &record.error {
-                *errors.entry(error.message.clone()).or_default() += 1;
-            }
-        }
-        let now = Instant::now();
         let start = measured.iter().min_by_key(|r| r.start);
         let end = measured.iter().max_by_key(|r| r.end);
-        let config = BenchmarkConfig {
-            model: args.model.as_deref().unwrap(),
-            tokenizer: args.tokenizer.as_deref().unwrap(),
-            mean_input_tokens: args.input_tokens,
-            stddev_input_tokens: args.input_tokens_stddev,
-            mean_output_tokens: args.output_cap,
-            stddev_output_tokens: args.output_cap_stddev,
-            num_concurrent_requests: args.concurrency,
-        };
-        let mut summary = build_summary(
-            &run_id,
-            &config,
-            &successful,
-            measured.len(),
-            successful.iter().map(|r| u64::from(r.input_tokens)).sum(),
-            successful.iter().map(|r| u64::from(r.output_tokens)).sum(),
-            successful
-                .iter()
-                .map(|r| u64::from(r.reasoning_tokens))
-                .sum(),
-            &errors,
-            start.map_or(now, |r| r.start),
-            end.map_or(now, |r| r.end),
-            start.map_or(0, |r| r.start_time_unix_ns),
-            end.map_or(0, |r| r.end_time_unix_ns),
-        );
-        summary.run_configuration =
-            Some(serde_json::to_value(args).expect("validated configuration is serializable"));
-        summary.termination = Some(
-            if interrupted {
+        let duration = start
+            .zip(end)
+            .map(|(a, b)| b.end.duration_since(a.start).as_secs_f64());
+        let mut values: BTreeMap<_, Vec<_>> = metric_values(&Metrics::default())
+            .into_iter()
+            .map(|(key, _)| (key, Vec::new()))
+            .collect();
+        let mut totals = TokenTotals::default();
+        let mut errors = BTreeMap::new();
+        for r in &measured {
+            if r.status == Status::Completed {
+                for (key, value) in metric_values(&r.metrics) {
+                    if let Some(value) = value {
+                        values.get_mut(key).unwrap().push(value);
+                    }
+                }
+                totals.input_tokens += r.metrics.input_tokens;
+                totals.content_tokens += r.metrics.content_tokens.unwrap_or(0);
+                totals.reasoning_tokens += r.metrics.reasoning_tokens.unwrap_or(0);
+                totals.generated_tokens += r.metrics.generated_tokens.unwrap_or(0);
+            }
+            if let Some(error) = &r.error {
+                *errors.entry(error.category).or_default() += 1;
+            }
+        }
+        let measurement = Counts::from_records(&measured);
+        let completion_fraction = (measurement.started > 0)
+            .then(|| measurement.completed as f64 / measurement.started as f64);
+        let rate_duration = duration.filter(|d| *d > 0.0);
+        Self {
+            version: "2026-09-06.1",
+            schema_version: "3.0",
+            llmnop_version: env!("CARGO_PKG_VERSION"),
+            run_id,
+            configuration: args,
+            termination: if interrupted {
                 "interrupted"
             } else {
                 "request_count"
-            }
-            .into(),
-        );
-        summary.warmup_attempts = Some(records.iter().filter(|r| r.phase == Phase::Warmup).count());
-        summary
+            },
+            start_time_unix_ns: start.map(|r| r.start_time_unix_ns),
+            end_time_unix_ns: end.map(|r| r.end_time_unix_ns),
+            measurement_duration_ms: duration.map(|d| d * 1000.0),
+            completed_requests_per_second: rate_duration.map(|d| measurement.completed as f64 / d),
+            completed_generated_tokens_per_second: rate_duration
+                .map(|d| totals.generated_tokens as f64 / d),
+            measurement,
+            warmup: Counts::from_records(&warmup),
+            completion_fraction,
+            metric_population: "completed_measurement_requests",
+            metrics: values
+                .into_iter()
+                .map(|(key, values)| (key, MetricStats::new(values)))
+                .collect(),
+            completed_token_totals: totals,
+            errors,
+        }
+    }
+
+    pub fn table(&self) -> String {
+        let mut table = Table::new();
+        table.load_style(UTF8_FULL_CONDENSED);
+        table.set_header(["Metric", "Samples", "Mean", "Median", "P95", "P99"]);
+        for (key, label) in [
+            ("request_latency_ms", "Request latency (ms)"),
+            ("ttft_ms", "Time to first token (ms)"),
+            ("ttfo_ms", "Time to first content (ms)"),
+            ("generation_tokens_per_second", "Generation rate (tokens/s)"),
+            (
+                "mean_inter_token_latency_ms",
+                "Estimated inter-token latency (ms)",
+            ),
+            ("mean_inter_event_latency_ms", "Mean stream-event gap (ms)"),
+            (
+                "max_inter_event_latency_ms",
+                "Longest stream-event gap (ms)",
+            ),
+            ("input_tokens", "Input tokens"),
+            ("content_tokens", "Content tokens"),
+            ("reasoning_tokens", "Exposed reasoning tokens"),
+            ("generated_tokens", "Generated tokens"),
+        ] {
+            let m = &self.metrics[key];
+            table.add_row(vec![
+                label.to_string(),
+                m.count.to_string(),
+                display(m.mean),
+                display(m.p50),
+                display(m.p95),
+                display(m.p99),
+            ]);
+        }
+        format!(
+            "{table}\n\nCompleted: {} / {}  Failed: {}  Timed out: {}  Cancelled: {}\nOutput-limit completions: {}  Empty completions: {}\nDuration: {} ms  Completed requests/s: {}  Generated tokens/s: {}\n",
+            self.measurement.completed,
+            self.measurement.started,
+            self.measurement.failed,
+            self.measurement.timed_out,
+            self.measurement.cancelled,
+            self.measurement.completed_at_output_limit,
+            self.measurement.completed_with_no_text,
+            display(self.measurement_duration_ms),
+            display(self.completed_requests_per_second),
+            display(self.completed_generated_tokens_per_second)
+        )
     }
 }
 
-pub fn print_records(records: &[RequestRecord]) {
-    let measured: Vec<_> = records
-        .iter()
-        .filter(|r| r.phase == Phase::Measurement)
-        .collect();
-    let successful: Vec<_> = measured
-        .iter()
-        .filter_map(|r| BenchmarkResult::from_record(r).ok())
-        .collect();
-    let now = Instant::now();
-    print_summary_to_stdout(
-        &successful,
-        measured.len() - successful.len(),
-        successful.iter().map(|r| u64::from(r.output_tokens)).sum(),
-        successful
-            .iter()
-            .map(|r| u64::from(r.reasoning_tokens))
-            .sum(),
-        measured.iter().map(|r| r.start).min().unwrap_or(now),
-        measured.iter().map(|r| r.end).max().unwrap_or(now),
-    );
+fn display(value: Option<f64>) -> String {
+    value
+        .map(|v| format!("{v:.2}"))
+        .unwrap_or_else(|| "—".to_string())
 }
+
 pub struct ResultsWriter {
     pub directory: PathBuf,
     pub run_id: String,
@@ -820,7 +312,7 @@ impl ResultsWriter {
         Ok(())
     }
 
-    pub async fn finish(&mut self, summary: &BenchmarkSummary) -> Result<()> {
+    pub async fn finish(&mut self, summary: &BenchmarkSummary<'_>) -> Result<()> {
         self.records.flush().await?;
         let path = self.directory.join("summary.json");
         tokio::fs::write(path, serde_json::to_vec_pretty(summary)?).await?;
@@ -831,163 +323,18 @@ impl ResultsWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
 
     #[test]
-    fn test_percentile_calculation() {
-        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0];
-
-        assert_eq!(percentile(&values, 0.0), 1.0);
-        assert_eq!(percentile(&values, 0.25), 2.0);
-        assert_eq!(percentile(&values, 0.5), 3.0);
-        assert_eq!(percentile(&values, 0.75), 4.0);
-        assert_eq!(percentile(&values, 1.0), 5.0);
-
-        assert_eq!(percentile(&[], 0.5), 0.0);
-        assert_eq!(percentile(&[42.0], 0.5), 42.0);
-    }
-
-    #[test]
-    fn test_quantiles_serialization() {
-        let quantiles = Quantiles {
-            p1: 0.01,
-            p5: 0.05,
-            p10: 0.1,
-            p25: 0.25,
-            p50: 0.5,
-            p75: 0.75,
-            p90: 0.9,
-            p95: 0.95,
-            p99: 0.99,
-        };
-
-        let json = serde_json::to_string(&quantiles).unwrap();
-        let deserialized: Quantiles = serde_json::from_str(&json).unwrap();
-
-        assert_eq!(deserialized.p10, 0.1);
-        assert_eq!(deserialized.p50, 0.5);
-        assert_eq!(deserialized.p99, 0.99);
-    }
-
-    #[test]
-    fn test_stats_computation() {
-        let values = vec![1.0, 2.0, 3.0, 4.0, 5.0];
-        let stats = compute_stats(&values);
-
-        assert_eq!(stats.mean, 3.0);
-        assert_eq!(stats.min, 1.0);
-        assert_eq!(stats.max, 5.0);
-        assert!(stats.stddev > 0.0);
-
-        assert!(stats.min <= stats.quantiles.p25);
-        assert!(stats.quantiles.p25 <= stats.quantiles.p50);
-        assert!(stats.quantiles.p75 <= stats.max);
-
-        let empty_stats = compute_stats(&[]);
-        assert_eq!(empty_stats.min, 0.0);
-        assert_eq!(empty_stats.max, 0.0);
-        assert_eq!(empty_stats.mean, 0.0);
-    }
-
-    #[test]
-    fn test_metric_stats_avg_only_serialization() {
-        let metric = metric_stats_avg_only("requests", 10.0);
-        let value = serde_json::to_value(metric).unwrap();
-
-        assert_eq!(value.get("unit").and_then(Value::as_str), Some("requests"));
-        assert_eq!(value.get("avg").and_then(Value::as_f64), Some(10.0));
-        assert!(value.get("p99").is_none());
-    }
-
-    #[test]
-    fn test_benchmark_slug() {
-        let config = BenchmarkConfig {
-            model: "qwen/qwen3-4b-2507",
-            tokenizer: "Qwen/Qwen3-4B",
-            mean_input_tokens: 550,
-            stddev_input_tokens: 0,
-            mean_output_tokens: Some(150),
-            stddev_output_tokens: 0,
-            num_concurrent_requests: 1,
-        };
-
-        assert_eq!(benchmark_slug(&config), "qwen-qwen3-4b-2507_550_150");
-    }
-
-    #[test]
-    fn test_benchmark_slug_without_output_tokens() {
-        let config = BenchmarkConfig {
-            model: "qwen/qwen3-4b-2507",
-            tokenizer: "Qwen/Qwen3-4B",
-            mean_input_tokens: 550,
-            stddev_input_tokens: 0,
-            mean_output_tokens: None,
-            stddev_output_tokens: 0,
-            num_concurrent_requests: 1,
-        };
-
-        assert_eq!(benchmark_slug(&config), "qwen-qwen3-4b-2507_550_none");
-    }
-
-    #[test]
-    fn test_build_summary_has_nested_metrics() {
-        let config = BenchmarkConfig {
-            model: "qwen/qwen3-4b-2507",
-            tokenizer: "Qwen/Qwen3-4B",
-            mean_input_tokens: 550,
-            stddev_input_tokens: 0,
-            mean_output_tokens: Some(150),
-            stddev_output_tokens: 0,
-            num_concurrent_requests: 1,
-        };
-
-        let successful_results = vec![BenchmarkResult {
-            ttft: Some(Duration::from_millis(100)),
-            ttfo: Some(Duration::from_millis(120)),
-            total_latency: Duration::from_millis(900),
-            throughput: Some(75.0),
-            input_tokens: 550,
-            output_tokens: 120,
-            reasoning_tokens: 30,
-            inter_token_latency_s: Some(0.01),
-            inter_event_latency_s: Some(0.02),
-            total_tokens: 700,
-            provider_usage: Some(ProviderUsage {
-                input_tokens: Some(550),
-                output_tokens: Some(150),
-                total_tokens: Some(700),
-                reasoning_tokens: Some(30),
-            }),
-            request_start_unix_ns: 1_700_000_000_000_000_000,
-            request_end_unix_ns: 1_700_000_000_900_000_000,
-        }];
-
-        let summary = build_summary(
-            "1700000000_123456789",
-            &config,
-            &successful_results,
-            1,
-            550,
-            120,
-            30,
-            &BTreeMap::new(),
-            std::time::Instant::now(),
-            std::time::Instant::now() + Duration::from_secs(1),
-            1_700_000_000_000_000_000,
-            1_700_000_001_000_000_000,
-        );
-
-        assert_eq!(summary.schema_version, "2.3");
-        assert_eq!(summary.version, "2026-09-06-lifecycle.1");
-        assert_eq!(summary.request_latency.unit, "ms");
-        assert_eq!(
-            summary.output_token_throughput_per_request.unit,
-            "tokens/sec/request"
-        );
-        assert!(summary.time_to_first_output_token.is_some());
-        assert_eq!(
-            summary.usage_output_tokens.and_then(|stats| stats.avg),
-            Some(150.0)
-        );
+    fn statistics_use_linear_percentiles_and_population_deviation() {
+        let stats = MetricStats::new(vec![5.0, 1.0, 3.0, 2.0, 4.0]);
+        assert_eq!(stats.count, 5);
+        assert_eq!(stats.mean, Some(3.0));
+        assert_eq!(stats.p50, Some(3.0));
+        assert_eq!(stats.p95, Some(4.8));
+        assert!((stats.stddev.unwrap() - 2f64.sqrt()).abs() < 1e-10);
+        let empty = MetricStats::new(vec![]);
+        assert_eq!(empty.count, 0);
+        assert_eq!(empty.mean, None);
+        assert_eq!(empty.p99, None);
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -100,7 +100,6 @@ pub struct TokenTotals {
 
 #[derive(Serialize)]
 pub struct BenchmarkSummary<'a> {
-    pub version: &'static str,
     pub schema_version: &'static str,
     pub llmnop_version: &'static str,
     pub run_id: String,
@@ -188,7 +187,6 @@ impl<'a> BenchmarkSummary<'a> {
             .then(|| measurement.completed as f64 / measurement.started as f64);
         let rate_duration = duration.filter(|d| *d > 0.0);
         Self {
-            version: "2026-09-06.1",
             schema_version: "3.0",
             llmnop_version: env!("CARGO_PKG_VERSION"),
             run_id,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::benchmark::Status;
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -323,7 +323,7 @@ async fn scheduler_bounds_concurrency_counts_failures_and_exports_recomputable_r
         "5",
         "--concurrency",
         "2",
-        "--quiet",
+        "--no-progress",
     ]);
     let client = client::http_client().unwrap();
     let tokenizer = Arc::new(tokens::test_tokenizer());
@@ -333,7 +333,7 @@ async fn scheduler_bounds_concurrency_counts_failures_and_exports_recomputable_r
     let (_tx, rx) = watch::channel(false);
     let parent = std::env::temp_dir().join(format!("llmnop-test-{}", benchmark::unix_time_ns()));
     let mut writer = ResultsWriter::new(Some(&parent)).await.unwrap();
-    let records = run_phase(&args, &client, &tokenizer, requests, &rx, &mut writer)
+    let mut records = run_phase(&args, &client, &tokenizer, requests, &rx, &mut writer)
         .await
         .unwrap();
     assert_eq!(records.len(), 5);
@@ -355,6 +355,11 @@ async fn scheduler_bounds_concurrency_counts_failures_and_exports_recomputable_r
     let mut ids: Vec<_> = records.iter().map(|r| r.request_id).collect();
     ids.sort_unstable();
     assert_eq!(ids, vec![0, 1, 2, 3, 4]);
+    let summary = BenchmarkSummary::new(&args, writer.run_id.clone(), &records, false);
+    writer.finish(&summary).await.unwrap();
+    assert_eq!(summary.measurement.completed, 4);
+    assert_eq!(summary.metrics["ttfo_ms"].count, 4);
+    assert_eq!(summary.completed_token_totals.generated_tokens, 8);
     let exported = tokio::fs::read_to_string(writer.directory.join("requests.jsonl"))
         .await
         .unwrap();
@@ -363,12 +368,41 @@ async fn scheduler_bounds_concurrency_counts_failures_and_exports_recomputable_r
         .map(|l| serde_json::from_str(l).unwrap())
         .collect();
     assert_eq!(rows.len(), 5);
-    assert_eq!(
-        rows.iter().filter(|r| r["status"] == "completed").count(),
-        4
-    );
+    let total: u64 = rows
+        .iter()
+        .filter(|r| r["status"] == "completed")
+        .map(|r| r["metrics"]["generated_tokens"].as_u64().unwrap())
+        .sum();
+    assert_eq!(total, summary.completed_token_totals.generated_tokens);
+    let rate = total as f64 / (summary.measurement_duration_ms.unwrap() / 1000.0);
+    assert_eq!(Some(rate), summary.completed_generated_tokens_per_second);
+    let duration_ns = records.iter().map(|r| r.end_time_unix_ns).max().unwrap()
+        - records.iter().map(|r| r.start_time_unix_ns).min().unwrap();
+    assert!((summary.measurement_duration_ms.unwrap() - duration_ns as f64 / 1e6).abs() < 1e-9);
+    records
+        .iter_mut()
+        .find(|r| r.status == Status::Completed)
+        .unwrap()
+        .phase = Phase::Warmup;
+    let without_warmup = BenchmarkSummary::new(&args, writer.run_id.clone(), &records, false);
+    assert_eq!(without_warmup.warmup.completed, 1);
+    assert_eq!(without_warmup.measurement.completed, 3);
+    assert_eq!(without_warmup.metrics["ttfo_ms"].count, 3);
+    assert_eq!(without_warmup.completed_token_totals.generated_tokens, 6);
     assert_eq!(finish_server(task).await.len(), 5);
     tokio::fs::remove_dir_all(parent).await.unwrap();
+}
+
+#[test]
+fn empty_summary_reports_missing_samples() {
+    let args = Args::parse_from(["llmnop"]);
+    let summary = BenchmarkSummary::new(&args, "test".into(), &[], true);
+    let json = serde_json::to_value(summary).unwrap();
+    assert_eq!(json["metrics"]["ttft_ms"]["count"], 0);
+    assert_eq!(json["metrics"]["ttft_ms"]["mean"], Value::Null);
+    assert_eq!(json["measurement_duration_ms"], Value::Null);
+    assert_eq!(json["termination"], "interrupted");
+    assert_eq!(json["configuration"]["api"], json!("chat"));
 }
 
 #[tokio::test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -323,7 +323,6 @@ async fn scheduler_bounds_concurrency_counts_failures_and_exports_recomputable_r
         "5",
         "--concurrency",
         "2",
-        "--no-progress",
     ]);
     let client = client::http_client().unwrap();
     let tokenizer = Arc::new(tokens::test_tokenizer());


### PR DESCRIPTION
## Summary

Write summary.json and requests.jsonl for every run, with explicit outcomes and statistics calculated from completed measurement requests.

## Changes

- Separate warmup outcomes from measurement outcomes.
- Include sample counts and represent unavailable measurements as null.
- Calculate aggregate throughput over the full measurement interval.
- Standardize table and JSON output and results-directory selection.
- Discard prompt and response text after processing rather than storing them in result artifacts.

