### PR TITLE
feat(cli): replace thinking budget with extra inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 - Support local tokenizer JSON files through `--tokenizer`. ([#69](https://github.com/jpreagan/llmnop/pull/69))
 - Add `--warmup` for requests completed before measurement and excluded from benchmark statistics. ([#71](https://github.com/jpreagan/llmnop/pull/71))
-- Restore `--results-dir`. ([#72](https://github.com/jpreagan/llmnop/pull/72))
+- Add `--results-dir` to choose where benchmark results are saved. ([#72](https://github.com/jpreagan/llmnop/pull/72))
 
 ### Changed
 
-- Replace `--thinking-budget` with `--extra-inputs` for additional API request settings, and save those settings in the run configuration. ([#74](https://github.com/jpreagan/llmnop/pull/74))
-- Rename `--mean-input-tokens` to `--input-tokens`, `--stddev-input-tokens` to `--input-tokens-stddev`, `--mean-output-tokens` to `--output-cap`, `--stddev-output-tokens` to `--output-cap-stddev`, and `--thinking-budget-tokens` to `--thinking-budget`. ([#69](https://github.com/jpreagan/llmnop/pull/69))
-- Replace `--max-num-completed-requests` and `--num-concurrent-requests` with `--requests` and `--concurrency`. Failed attempts count toward the request budget and are not retried. ([#71](https://github.com/jpreagan/llmnop/pull/71))
+- Replace `--thinking-budget-tokens` with `--extra-inputs` for additional API request settings, and save those settings in the run configuration. ([#74](https://github.com/jpreagan/llmnop/pull/74))
+- Rename `--mean-input-tokens` to `--input-tokens`, `--stddev-input-tokens` to `--input-tokens-stddev`, `--mean-output-tokens` to `--output-cap`, and `--stddev-output-tokens` to `--output-cap-stddev`. ([#69](https://github.com/jpreagan/llmnop/pull/69))
+- Replace `--max-num-completed-requests` and `--num-concurrent-requests` with `--requests` and `--concurrency`. ([#71](https://github.com/jpreagan/llmnop/pull/71))
 - Replace the benchmark-wide `--timeout` with a per-request `--request-timeout`. Save partial results on timeout or interruption. ([#71](https://github.com/jpreagan/llmnop/pull/71))
-- Rename `individual_responses.jsonl` to `requests.jsonl` and revise the JSON result schema to include separate warmup outcomes, sample counts, and null values for unavailable measurements. Calculate summary statistics from completed measurement requests. ([#72](https://github.com/jpreagan/llmnop/pull/72))
+- Rename `individual_responses.jsonl` to `requests.jsonl` and update the JSON result schema from `2.0` to `3.0`, with separate warmup outcomes, per-metric sample counts, and null values for unavailable measurements. Exclude warmup and unavailable measurements from summary metric statistics. ([#72](https://github.com/jpreagan/llmnop/pull/72))
 - Replace `--output-format`, `--json`, and `--quiet` with `--format table|json|none`, and rename `--use-server-token-count` to `--request-usage`. ([#72](https://github.com/jpreagan/llmnop/pull/72))
 
 ### Removed
@@ -27,6 +27,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Fixed
 
+- Calculate per-request generation rate as `(generated_tokens - 1) / generation_window_seconds` instead of `generated_tokens / generation_window_seconds`, making it the reciprocal of estimated inter-token latency. ([#70](https://github.com/jpreagan/llmnop/pull/70))
+- Return a nonzero exit status when benchmark requests fail or time out, and exit with status `130` when interrupted. ([#71](https://github.com/jpreagan/llmnop/pull/71))
 - Ensure generated prompts match their requested token counts or fail explicitly when that target cannot be met. ([#69](https://github.com/jpreagan/llmnop/pull/69))
 - Report malformed or prematurely terminated streams as failed requests, and calculate content and reasoning timings consistently across supported APIs, leaving measurements absent when no qualifying text arrives. ([#70](https://github.com/jpreagan/llmnop/pull/70))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ### Changed
 
+- Replace `--thinking-budget` with `--extra-inputs` for additional API request settings, and save those settings in the run configuration. ([#74](https://github.com/jpreagan/llmnop/pull/74))
 - Rename `--mean-input-tokens` to `--input-tokens`, `--stddev-input-tokens` to `--input-tokens-stddev`, `--mean-output-tokens` to `--output-cap`, `--stddev-output-tokens` to `--output-cap-stddev`, and `--thinking-budget-tokens` to `--thinking-budget`. ([#69](https://github.com/jpreagan/llmnop/pull/69))
 - Replace `--max-num-completed-requests` and `--num-concurrent-requests` with `--requests` and `--concurrency`. Failed attempts count toward the request budget and are not retried. ([#71](https://github.com/jpreagan/llmnop/pull/71))
 - Replace the benchmark-wide `--timeout` with a per-request `--request-timeout`. Save partial results on timeout or interruption. ([#71](https://github.com/jpreagan/llmnop/pull/71))

--- a/README.md
+++ b/README.md
@@ -138,9 +138,19 @@ and actual locally measured counts; it does not infer a limit finish merely from
 those counts. Reasoning's contribution to the provider's cap depends on its API
 and model.
 
-`--thinking-budget` enables Messages thinking. It must be at least 1024 and below
-the mean output cap. Every sampled cap also exceeds the thinking budget.
 A nonzero output-cap standard deviation requires an output cap.
+
+`--extra-inputs` accepts one JSON object of additional request fields. Fields are merged at the top level and sent unchanged on every request, including warmup. For example:
+
+```bash
+--extra-inputs '{"reasoning_effort":"high","temperature":0.7}'
+--extra-inputs '{"reasoning":{"effort":"high"}}'
+--extra-inputs '{"thinking":{"type":"enabled","budget_tokens":1024}}'
+```
+
+These examples configure Chat reasoning effort, Responses reasoning effort, and Messages thinking respectively. Supported fields, values, and defaults depend on the model and server; llmnop does not translate or validate their meaning. For Messages thinking, choose an output cap that satisfies the endpoint's requirements. Variable output caps are not adjusted around a thinking budget.
+
+The fields `model`, `stream`, `messages`, `input`, `prompt`, `max_tokens`, `max_completion_tokens`, `max_output_tokens`, and `stream_options` are reserved and rejected, even when the corresponding option is omitted. Use llmnop's workload and usage controls for those fields. Additional fields are saved verbatim under `configuration.extra_inputs` in `summary.json`; keep authentication credentials in `--api-key`.
 
 `--tokenizer` accepts a Hugging Face identifier or a local `tokenizer.json` file.
 The default identifier is the model name. Tokenizer truncation and padding are
@@ -228,7 +238,7 @@ becomes `requests.jsonl`.
 | `--stddev-input-tokens` | `--input-tokens-stddev` |
 | `--mean-output-tokens` | `--output-cap` |
 | `--stddev-output-tokens` | `--output-cap-stddev` |
-| `--thinking-budget-tokens` | `--thinking-budget` |
+| `--thinking-budget-tokens`, `--thinking-budget` | `--extra-inputs '{"thinking":{"type":"enabled","budget_tokens":1024}}'` |
 | `--max-num-completed-requests` | `--requests`, `-n` |
 | `--num-concurrent-requests` | `--concurrency`, `-c` |
 | `--timeout` | `--request-timeout` (now a per-request deadline) |

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,6 +3,7 @@ use clap::builder::styling::{AnsiColor, Effects};
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use serde::Serialize;
+use serde_json::{Map, Value};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -32,6 +33,28 @@ const STYLES: Styles = Styles::styled()
     .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
     .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
     .placeholder(AnsiColor::Cyan.on_default());
+
+fn parse_extra_inputs(input: &str) -> Result<Map<String, Value>, String> {
+    let extra: Map<String, Value> =
+        serde_json::from_str(input).map_err(|e| format!("expected a JSON object: {e}"))?;
+    for key in extra.keys() {
+        if matches!(
+            key.as_str(),
+            "model"
+                | "stream"
+                | "messages"
+                | "input"
+                | "prompt"
+                | "max_tokens"
+                | "max_completion_tokens"
+                | "max_output_tokens"
+                | "stream_options"
+        ) {
+            return Err(format!("{key} is controlled by llmnop"));
+        }
+    }
+    Ok(extra)
+}
 
 #[derive(Parser, Debug, Serialize)]
 #[command(version, about, long_about = None, styles = STYLES, subcommand_negates_reqs = true)]
@@ -95,8 +118,8 @@ pub struct Args {
         help_heading = "Workload"
     )]
     pub output_cap_stddev: u32,
-    #[arg(long, value_name = "N", value_parser = clap::value_parser!(u32).range(1024..), help = "Messages API thinking-token budget", help_heading = "Workload")]
-    pub thinking_budget: Option<u32>,
+    #[arg(long, value_name = "JSON", value_parser = parse_extra_inputs, help = "Additional request fields as a JSON object", help_heading = "Workload")]
+    pub extra_inputs: Option<Map<String, Value>>,
     #[arg(short = 'n', long, value_name = "N", default_value_t = 10, value_parser = clap::value_parser!(u32).range(1..), help = "Measured request attempts", help_heading = "Run")]
     pub requests: u32,
     #[arg(short = 'c', long, value_name = "N", default_value_t = 1, value_parser = clap::value_parser!(u32).range(1..), help = "Maximum simultaneous requests", help_heading = "Run")]
@@ -173,14 +196,6 @@ impl Args {
         if self.output_cap_stddev > 0 && self.output_cap.is_none() {
             return Err(invalid("--output-cap-stddev requires --output-cap"));
         }
-        if let Some(budget) = self.thinking_budget {
-            if self.api != ApiType::Messages {
-                return Err(invalid("--thinking-budget requires --api messages"));
-            }
-            if self.output_cap.is_none_or(|cap| cap <= budget) {
-                return Err(invalid("--output-cap must exceed --thinking-budget"));
-            }
-        }
         if Duration::try_from_secs_f64(self.request_timeout).is_err() || self.request_timeout <= 0.0
         {
             return Err(invalid(
@@ -214,18 +229,9 @@ mod tests {
             vec!["--input-tokens", "0"],
             vec!["--output-cap", "0"],
             vec!["--api", "messages"],
-            vec!["--thinking-budget", "1024"],
             vec!["--output-cap-stddev", "1"],
             vec!["--request-timeout", "NaN"],
             vec!["--request-timeout", "0"],
-            vec![
-                "--api",
-                "messages",
-                "--output-cap",
-                "1024",
-                "--thinking-budget",
-                "1024",
-            ],
         ] {
             let mut argv = vec!["llmnop", "--url", "http://localhost/v1", "--model", "test"];
             argv.extend(flags);
@@ -239,7 +245,45 @@ mod tests {
         assert_eq!(help.kind(), ErrorKind::DisplayHelp);
         assert!(help.to_string().contains("standalone installs only"));
         assert!(!help.to_string().contains("env:"));
+        assert!(help.to_string().contains("--extra-inputs <JSON>"));
+        assert!(!help.to_string().contains("--thinking-budget"));
         assert!(Args::try_parse_from(["llmnop", "update"]).is_ok());
+    }
+
+    #[test]
+    fn extra_inputs_require_an_object_and_protect_benchmark_fields() {
+        for input in ["null", "[]", "true", "42", "\"text\"", "{", "{} trailing"] {
+            assert!(Args::try_parse_from(["llmnop", "--extra-inputs", input]).is_err());
+        }
+        for api in ["chat", "responses", "messages"] {
+            for key in [
+                "model",
+                "stream",
+                "messages",
+                "input",
+                "prompt",
+                "max_tokens",
+                "max_completion_tokens",
+                "max_output_tokens",
+                "stream_options",
+            ] {
+                let input = serde_json::json!({key: null}).to_string();
+                let error =
+                    Args::try_parse_from(["llmnop", "--api", api, "--extra-inputs", &input])
+                        .unwrap_err();
+                assert_eq!(error.kind(), ErrorKind::ValueValidation);
+                assert!(
+                    error
+                        .to_string()
+                        .contains(&format!("{key} is controlled by llmnop"))
+                );
+            }
+        }
+        assert!(
+            Args::try_parse_from(["llmnop", "--extra-inputs", "{}", "--extra-inputs", "{}"])
+                .is_err()
+        );
+        assert!(Args::try_parse_from(["llmnop", "--thinking-budget", "1024"]).is_err());
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,7 @@ use crate::args::ApiType;
 use anyhow::{Context, Result};
 use reqwest::{Client, Request};
 use serde::Serialize;
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct Failure {
@@ -32,7 +32,7 @@ pub fn request_body(
     model: &str,
     prompt: &str,
     cap: Option<u32>,
-    thinking: Option<u32>,
+    extra: Option<&Map<String, Value>>,
     usage: bool,
 ) -> Value {
     let mut body = json!({"model": model, "stream": true});
@@ -52,8 +52,8 @@ pub fn request_body(
     if api == ApiType::Chat && usage {
         body["stream_options"] = json!({"include_usage": true});
     }
-    if let Some(budget) = thinking {
-        body["thinking"] = json!({"type":"enabled", "budget_tokens":budget});
+    if let Some(extra) = extra {
+        body.as_object_mut().unwrap().extend(extra.clone());
     }
     body
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,17 +38,10 @@ fn prepare(
     let mut rng = rand::rng();
     for index in 0..count {
         let input_target =
-            prompt::sample_length(&mut rng, args.input_tokens, args.input_tokens_stddev, 1)?;
+            prompt::sample_length(&mut rng, args.input_tokens, args.input_tokens_stddev)?;
         let cap = args
             .output_cap
-            .map(|mean| {
-                prompt::sample_length(
-                    &mut rng,
-                    mean,
-                    args.output_cap_stddev,
-                    args.thinking_budget.map_or(1, |b| b + 1),
-                )
-            })
+            .map(|mean| prompt::sample_length(&mut rng, mean, args.output_cap_stddev))
             .transpose()?;
         let prompt = generator.generate(&mut rng, input_target)?;
         let input_tokens = tokens::count(tokenizer, &prompt)?;
@@ -57,7 +50,7 @@ fn prepare(
             args.model.as_deref().unwrap(),
             &prompt,
             cap,
-            args.thinking_budget,
+            args.extra_inputs.as_ref(),
             args.request_usage,
         );
         prepared.push_back(PreparedRequest {

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -4,23 +4,15 @@ use rand_distr::{Distribution, Normal};
 use tokenizers::Tokenizer;
 
 pub const CORPUS: &str = include_str!("assets/shakespeare.txt");
-pub fn sample_length(
-    rng: &mut impl rand::Rng,
-    mean: u32,
-    stddev: u32,
-    minimum: u32,
-) -> Result<u32> {
+pub fn sample_length(rng: &mut impl rand::Rng, mean: u32, stddev: u32) -> Result<u32> {
     if stddev == 0 {
-        return Ok(mean.max(minimum));
+        return Ok(mean.max(1));
     }
     let normal = Normal::new(f64::from(mean), f64::from(stddev))?;
     for _ in 0..10_000 {
         let sample = normal.sample(rng);
         if sample >= 0.0 && sample.ceil() <= f64::from(u32::MAX) {
-            let n = (sample.ceil() as u32).max(1);
-            if n >= minimum {
-                return Ok(n);
-            }
+            return Ok((sample.ceil() as u32).max(1));
         }
     }
     bail!("could not sample a length within the requested bounds")
@@ -179,10 +171,10 @@ mod tests {
     }
 
     #[test]
-    fn caps_stay_above_thinking_budget() {
+    fn sampled_lengths_are_positive() {
         let mut rng = StdRng::seed_from_u64(2);
         for _ in 0..1000 {
-            assert!(sample_length(&mut rng, 1100, 300, 1025).unwrap() > 1024);
+            assert!(sample_length(&mut rng, 1, 10).unwrap() > 0);
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -124,11 +124,49 @@ async fn all_three_wire_formats_preserve_local_counts_and_provider_usage() {
     ] {
         let (url, task, _) = server(vec![Reply::sse(payload)]).await;
         let client = client::http_client().unwrap();
+        let mut extra = match api {
+            args::ApiType::Chat => json!({"reasoning_effort": "high"}),
+            args::ApiType::Responses => json!({"reasoning": {"effort": "high"}}),
+            args::ApiType::Messages => {
+                json!({"thinking": {"type": "enabled", "budget_tokens": 1024}})
+            }
+        };
+        extra["temperature"] = json!(0.5);
+        extra["vendor"] = json!({"enabled": true, "values": [1, "two", null], "model": "nested"});
+        let config = Args::parse_from([
+            "llmnop",
+            "--url",
+            &url,
+            "--model",
+            "test",
+            "--api-key",
+            "test-secret",
+            "--api",
+            match api {
+                args::ApiType::Chat => "chat",
+                args::ApiType::Responses => "responses",
+                args::ApiType::Messages => "messages",
+            },
+            "--requests",
+            "1",
+            "--input-tokens",
+            "2",
+            "--output-cap",
+            "8",
+            "--request-usage",
+            "--extra-inputs",
+            &serde_json::to_string(&extra).unwrap(),
+        ]);
+        config.validate().unwrap();
+        let tokenizer = tokens::test_tokenizer();
+        let generator = PromptGenerator::new(&tokenizer).unwrap();
+        let mut requests =
+            prepare(&config, &client, &tokenizer, &generator, Phase::Measurement).unwrap();
         let (_tx, rx) = watch::channel(false);
         let record = benchmark::capture(
             client.clone(),
             api,
-            prepared(&client, api, &url, 0),
+            requests.pop_front().unwrap(),
             Duration::from_secs(2),
             rx,
         )
@@ -148,6 +186,13 @@ async fn all_three_wire_formats_preserve_local_counts_and_provider_usage() {
         let wire = finish_server(task).await;
         let (headers, body) = &wire[0];
         assert_eq!(body["stream"], true);
+        for (key, value) in extra.as_object().unwrap() {
+            assert_eq!(&body[key], value);
+        }
+        let summary = BenchmarkSummary::new(&config, "test".into(), &[], false);
+        let saved = serde_json::to_value(summary).unwrap();
+        assert_eq!(saved["configuration"]["extra_inputs"], json!(extra));
+        assert!(saved["configuration"].get("thinking_budget").is_none());
         assert!(headers.contains(if api == args::ApiType::Messages {
             "x-api-key: test-secret"
         } else {


### PR DESCRIPTION
## Summary

Replace `--thinking-budget` with `--extra-inputs` so users can supply reasoning, sampling, and other API-specific settings as one JSON object.

Additional fields are sent with every request and saved in the run configuration. Fields controlled by llmnop remain protected against overrides. Remove thinking-specific validation and output-cap adjustments, leaving interpretation of additional settings to the endpoint.
